### PR TITLE
Create custom storage class for SpectralData sample data file.

### DIFF
--- a/biospecdb/apps/uploader/io.py
+++ b/biospecdb/apps/uploader/io.py
@@ -2,7 +2,9 @@ from io import IOBase
 from pathlib import Path
 
 import django.core.files
+from django.core.files.storage import FileSystemStorage
 import django.core.files.uploadedfile
+from django.utils.deconstruct import deconstructible
 import pandas as pd
 
 from biospecdb.util import StrEnum, to_uuid
@@ -112,3 +114,10 @@ def get_file_info(file_wrapper):
     if hasattr(file, "closed") and not file.closed and hasattr(file, "seek"):
         file.seek(0)
     return file, Path(file_wrapper.name).suffix
+
+
+@deconstructible(path="biospecdb.apps.uploader.io.SpectralDataFileStorage")
+class SpectralDataFileStorage(FileSystemStorage):
+    def _save(self, name, content):
+        saved_file_path = super()._save(name, content)
+        return saved_file_path

--- a/biospecdb/apps/uploader/models.py
+++ b/biospecdb/apps/uploader/models.py
@@ -12,7 +12,8 @@ from django.utils.translation import gettext_lazy as _
 import pandas as pd
 
 from biospecdb.qc.qcfilter import QcFilter
-from uploader.io import FileFormats, get_file_info, read_meta_data, read_spectral_data_table, spectral_data_from_csv
+from uploader.io import FileFormats, get_file_info, read_meta_data, read_spectral_data_table, spectral_data_from_csv, \
+    SpectralDataFileStorage
 from uploader.loaddata import save_data_to_db
 from uploader.sql import secure_name
 from uploader.base_models import DatedModel, ModelWithViewDependency, SqlView, TextChoices, Types
@@ -342,7 +343,8 @@ class SpectralData(DatedModel):
     # See https://docs.djangoproject.com/en/4.2/howto/custom-file-storage/
     data = models.FileField(upload_to=UPLOAD_DIR,
                             validators=[FileExtensionValidator(UploadedFile.FileFormats.choices())],
-                            verbose_name="Spectral data file")
+                            verbose_name="Spectral data file",
+                            storage=SpectralDataFileStorage)
 
     def __str__(self):
         return f"{self.bio_sample.visit}_pk{self.pk}"


### PR DESCRIPTION
Superseded by #167 

Core achievables:
- [ ] Bake patient_id (maybe also patient_cid) into spectral data files.
- [ ] Allow reingestion of the on-disk file format.