### PR TITLE
Deactivate data input form

### DIFF
--- a/biospecdb/apps/uploader/templates/Home.html
+++ b/biospecdb/apps/uploader/templates/Home.html
@@ -63,18 +63,18 @@
                   </table>
               </div>
             
-              <div class="app-uploader module">
-                  <table>
-                  <caption>
-                    <a href="../uploader/data_input/" class="section" title="Data Input/Search form">Data Input/Search form</a>
-                  </caption>
-                      <tbody>
-                        <tr class="model-biosample">
-                          <th scope="row">Insert/Search the patient's data</a></th>
-                        </tr>
-                      </tbody>
-                  </table>
-              </div>
+{#              <div class="app-uploader module">#}
+{#                  <table>#}
+{#                  <caption>#}
+{#                    <a href="../uploader/data_input/" class="section" title="Data Input/Search form">Data Input/Search form</a>#}
+{#                  </caption>#}
+{#                      <tbody>#}
+{#                        <tr class="model-biosample">#}
+{#                          <th scope="row">Insert/Search the patient's data</a></th>#}
+{#                        </tr>#}
+{#                      </tbody>#}
+{#                  </table>#}
+{#              </div>#}
             
               <div class="owner module">
                   <table>

--- a/biospecdb/apps/uploader/tests/test_forms.py
+++ b/biospecdb/apps/uploader/tests/test_forms.py
@@ -2,9 +2,11 @@ from django.core.exceptions import ValidationError
 import django.core.files
 import pytest
 
-from uploader.models import UploadedFile, Patient, Visit, BioSample, SpectralData, Instrument, Disease
-from uploader.forms import DataInputForm
-from uploader.tests.conftest import DATA_PATH
+pytest.skip(allow_module_level=True)
+
+from uploader.models import UploadedFile, Patient, Visit, BioSample, SpectralData, Instrument, Disease  # noqa: E402
+from uploader.forms import DataInputForm  # noqa: E402
+from uploader.tests.conftest import DATA_PATH  # noqa: E402
 
 
 @pytest.fixture()

--- a/biospecdb/apps/uploader/urls.py
+++ b/biospecdb/apps/uploader/urls.py
@@ -1,12 +1,12 @@
-from django.urls import path
+# from django.urls import path
 from django.conf import settings
 from django.conf.urls.static import static
-from . import views
+# from . import views
 
 app_name = 'uploader'
 
 urlpatterns = [
-    path('data_input/', views.data_input, name='DataInputForm')
+    # path('data_input/', views.data_input, name='DataInputForm')
 ]
 
 if settings.DEBUG:

--- a/biospecdb/apps/uploader/views.py
+++ b/biospecdb/apps/uploader/views.py
@@ -37,6 +37,8 @@ def display_xlsx(request):
 
 @staff_member_required
 def data_input(request):
+    raise NotImplementedError
+
     message = ""
     form = DataInputForm(request=request)
     delta_count = len(form.base_fields) - 1


### PR DESCRIPTION
The plan is to bench this until everything else is complete and functional. Then we'll work on the UI. The data input form is about to get broken by a bunch of things and there's no bandwidth to keep it in step as the backend is developed - especially when we're going to significantly change this form anyhow.