### PR TITLE
Add nested inline forms for patient data input

### DIFF
--- a/biospecdb/settings.py
+++ b/biospecdb/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    "nested_inline",
     "explorer",
     "uploader.apps.UploaderConfig",
     "user.apps.UserConfig"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ license = {file = "LICENSE"}
 requires-python = ">=3.11"
 dependencies = [
     "django",
+    "django-nested-inline",
     "django-sql-explorer[charts]",
     "kaleido",
     "openpyxl",

--- a/requirements/prd.txt
+++ b/requirements/prd.txt
@@ -1,4 +1,5 @@
 django==4.2.7
+django-nested-inline==0.4.6
 django-sql-explorer[charts]==3.2.1
 kaleido==0.2.1
 openpyxl==3.1.2


### PR DESCRIPTION
This uses [django-nested-inline](https://github.com/OskarPersson/django-nested-inline). However, it appears that this package seems fairly buggy. Namey permissions issues and also the inability to save files in multi-nested inlines, i.e., our spectral data files.

Looking at the package issues and open PRs, these are known issues, some with fixes in open PRs, however, I'm not optimistic that this is a good package for us to use.