### PR TITLE
Add models.Observable.category

### DIFF
--- a/biospecdb/apps/uploader/admin.py
+++ b/biospecdb/apps/uploader/admin.py
@@ -142,8 +142,8 @@ class ObservableAdmin(RestrictedByCenterAdmin):
     search_help_text = "Observable name"
     readonly_fields = ["created_at", "updated_at"]  # TODO: Might need specific user group.
     ordering = ["name"]
-    list_filter = ("center", "value_class")
-    list_display = ["name", "description", "observation_count"]
+    list_filter = ("center", "category", "value_class")
+    list_display = ["category", "name", "description", "observation_count"]
 
     @admin.display
     def observation_count(self, obj):

--- a/biospecdb/apps/uploader/admin.py
+++ b/biospecdb/apps/uploader/admin.py
@@ -164,7 +164,7 @@ class ObservationAdmin(RestrictedByCenterAdmin):
     readonly_fields = ["created_at", "updated_at"]  # TODO: Might need specific user group.
     date_hierarchy = "updated_at"
     ordering = ("-updated_at",)
-    list_filter = ("visit__patient__center", "visit__patient__gender", "observable")
+    list_filter = ("visit__patient__center", "observable__category", "visit__patient__gender", "observable")
     list_display = ["patient_id", "observable_name", "days_observed", "severity", "visit"]
     list_editable = ["days_observed", "severity"]
 

--- a/biospecdb/apps/uploader/fixtures/observables.json
+++ b/biospecdb/apps/uploader/fixtures/observables.json
@@ -3,6 +3,7 @@
     "model": "uploader.Observable",
     "pk": 1,
     "fields": {
+      "category": "TEST",
       "name": "Ct_gene_N",
       "description": "Covid cycle threshold N gene detection",
       "alias": "CTs (Gene N)",
@@ -15,6 +16,7 @@
     "model": "uploader.Observable",
     "pk": 2,
     "fields": {
+      "category": "TEST",
       "name": "Ct_gene_ORF1ab",
       "description": "Covid cycle threshold for ORF1ab detection",
       "alias": "CTs (Gene ORF)",
@@ -27,6 +29,7 @@
     "model": "uploader.Observable",
     "pk": 3,
     "fields": {
+      "category": "TEST",
       "name": "Covid_RT_qPCR",
       "description": "Covid RT qPCR results",
       "alias": "RESULT RT-qPCR",
@@ -39,6 +42,7 @@
     "model": "uploader.Observable",
     "pk": 4,
     "fields": {
+      "category": "SYMPTOM",
       "name": "covid_suspicious_contact",
       "description": "Suspicious contact of Covid",
       "alias": "Suspicious contact",
@@ -51,6 +55,7 @@
     "model": "uploader.Observable",
     "pk": 5,
     "fields": {
+      "category": "SYMPTOM",
       "name": "fever",
       "description": "Patient experiences a fever?",
       "alias": "fever",
@@ -63,6 +68,7 @@
     "model": "uploader.Observable",
     "pk": 6,
     "fields": {
+      "category": "SYMPTOM",
       "name": "dyspnoea",
       "description": "Difficult or labored breathing",
       "alias": "dyspnoea",
@@ -75,6 +81,7 @@
     "model": "uploader.Observable",
     "pk": 7,
     "fields": {
+      "category": "VITALS",
       "name": "oxygen_saturation_lt_95",
       "description": "Blood oxygen saturation less than 95%",
       "alias": "O2 Sat <95%",
@@ -87,6 +94,7 @@
     "model": "uploader.Observable",
     "pk": 8,
     "fields": {
+      "category": "SYMPTOM",
       "name": "cough",
       "description": "Patient experiences cough-like symptoms.",
       "alias": "cough",
@@ -99,6 +107,7 @@
     "model": "uploader.Observable",
     "pk": 9,
     "fields": {
+      "category": "SYMPTOM",
       "name": "coryza",
       "description": "Irritation and inflammation of the nasal mucous membrane.",
       "alias": "coryza",
@@ -111,6 +120,7 @@
     "model": "uploader.Observable",
     "pk": 10,
     "fields": {
+      "category": "SYMPTOM",
       "name": "odinophagy",
       "description": "Pain when swallowing.",
       "alias": "odinophagy",
@@ -123,6 +133,7 @@
     "model": "uploader.Observable",
     "pk": 11,
     "fields": {
+      "category": "SYMPTOM",
       "name": "diarrhea",
       "description": "Patient experiences diarrhea.",
       "alias": "diarrhea",
@@ -135,6 +146,7 @@
     "model": "uploader.Observable",
     "pk": 12,
     "fields": {
+      "category": "SYMPTOM",
       "name": "nausea",
       "description": "Patient experiences nausea.",
       "alias": "nausea",
@@ -147,6 +159,7 @@
     "model": "uploader.Observable",
     "pk": 13,
     "fields": {
+      "category": "SYMPTOM",
       "name": "headache",
       "description": "Patient experiences headaches.",
       "alias": "headache",
@@ -159,6 +172,7 @@
     "model": "uploader.Observable",
     "pk": 14,
     "fields": {
+      "category": "SYMPTOM",
       "name": "weakness",
       "description": "Patient experiences weakness or fatigue.",
       "alias": "weakness",
@@ -171,6 +185,7 @@
     "model": "uploader.Observable",
     "pk": 15,
     "fields": {
+      "category": "SYMPTOM",
       "name": "anosmia",
       "description": "Partial or complete loss of smell.",
       "alias": "anosmia",
@@ -183,6 +198,7 @@
     "model": "uploader.Observable",
     "pk": 16,
     "fields": {
+      "category": "SYMPTOM",
       "name": "myalgia",
       "description": "Muscular aches and pains.",
       "alias": "myalgia",
@@ -195,6 +211,7 @@
     "model": "uploader.Observable",
     "pk": 17,
     "fields": {
+      "category": "SYMPTOM",
       "name": "no_appetite",
       "description": "Lack of appetite",
       "alias": "Lack of appetite",
@@ -207,6 +224,7 @@
     "model": "uploader.Observable",
     "pk": 18,
     "fields": {
+      "category": "SYMPTOM",
       "name": "vomiting",
       "description": "Patient experiences vomiting",
       "alias": "vomiting",
@@ -219,6 +237,7 @@
     "model": "uploader.Observable",
     "pk": 19,
     "fields": {
+      "category": "COMORBIDITY",
       "name": "chronic_pulmonary_inc_asthma",
       "description": "Chronic pulmonary conditions including asthma",
       "alias": "Chronic pulmonary disease including asthma",
@@ -231,6 +250,7 @@
     "model": "uploader.Observable",
     "pk": 20,
     "fields": {
+      "category": "COMORBIDITY",
       "name": "cardiovascular_disease_inc_hypertension",
       "description": "Cardiovascular disease including hypertension.",
       "alias": "Cardiovascular disease including hypertension",
@@ -243,6 +263,7 @@
     "model": "uploader.Observable",
     "pk": 21,
     "fields": {
+      "category": "COMORBIDITY",
       "name": "diabetes",
       "description": "Diabetes type 1 & type 2.",
       "alias": "diabetes",
@@ -255,6 +276,7 @@
     "model": "uploader.Observable",
     "pk": 22,
     "fields": {
+      "category": "COMORBIDITY",
       "name": "chronic_or_neuromuscular_neurological_disease",
       "description": "Chronic or neuromuscular neurological disease.",
       "alias": "Chronic or neuromuscular neurological disease",

--- a/biospecdb/apps/uploader/fixtures/test_data.json
+++ b/biospecdb/apps/uploader/fixtures/test_data.json
@@ -215,6 +215,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "TEST",
         "name": "Ct_gene_N",
         "description": "Covid cycle threshold N gene detection",
         "alias": "CTs (Gene N)",
@@ -227,6 +228,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "TEST",
         "name": "Ct_gene_ORF1ab",
         "description": "Covid cycle threshold for ORF1ab detection",
         "alias": "CTs (Gene ORF)",
@@ -239,6 +241,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "TEST",
         "name": "Covid_RT_qPCR",
         "description": "Covid RT qPCR results",
         "alias": "RESULT RT-qPCR",
@@ -251,6 +254,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "SYMPTOM",
         "name": "covid_suspicious_contact",
         "description": "Suspicious contact of Covid",
         "alias": "Suspicious contact",
@@ -263,6 +267,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "SYMPTOM",
         "name": "fever",
         "description": "Patient experiences a fever?",
         "alias": "fever",
@@ -275,6 +280,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "SYMPTOM",
         "name": "dyspnoea",
         "description": "Difficult or labored breathing",
         "alias": "dyspnoea",
@@ -287,6 +293,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "VITALS",
         "name": "oxygen_saturation_lt_95",
         "description": "Blood oxygen saturation less than 95%",
         "alias": "O2 Sat <95%",
@@ -299,6 +306,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "SYMPTOM",
         "name": "cough",
         "description": "Patient experiences cough-like symptoms.",
         "alias": "cough",
@@ -311,6 +319,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "SYMPTOM",
         "name": "coryza",
         "description": "Irritation and inflammation of the nasal mucous membrane.",
         "alias": "coryza",
@@ -323,6 +332,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "SYMPTOM",
         "name": "odinophagy",
         "description": "Pain when swallowing.",
         "alias": "odinophagy",
@@ -335,6 +345,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "SYMPTOM",
         "name": "diarrhea",
         "description": "Patient experiences diarrhea.",
         "alias": "diarrhea",
@@ -347,6 +358,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "SYMPTOM",
         "name": "nausea",
         "description": "Patient experiences nausea.",
         "alias": "nausea",
@@ -359,6 +371,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "SYMPTOM",
         "name": "headache",
         "description": "Patient experiences headaches.",
         "alias": "headache",
@@ -371,6 +384,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "SYMPTOM",
         "name": "weakness",
         "description": "Patient experiences weakness or fatigue.",
         "alias": "weakness",
@@ -383,6 +397,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "SYMPTOM",
         "name": "anosmia",
         "description": "Partial or complete loss of smell.",
         "alias": "anosmia",
@@ -395,6 +410,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "SYMPTOM",
         "name": "myalgia",
         "description": "Muscular aches and pains.",
         "alias": "myalgia",
@@ -407,6 +423,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "SYMPTOM",
         "name": "no_appetite",
         "description": "Lack of appetite",
         "alias": "Lack of appetite",
@@ -419,6 +436,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "SYMPTOM",
         "name": "vomiting",
         "description": "Patient experiences vomiting",
         "alias": "vomiting",
@@ -431,6 +449,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "COMORBIDITY",
         "name": "chronic_pulmonary_inc_asthma",
         "description": "Chronic pulmonary conditions including asthma",
         "alias": "Chronic pulmonary disease including asthma",
@@ -443,6 +462,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "COMORBIDITY",
         "name": "cardiovascular_disease_inc_hypertension",
         "description": "Cardiovascular disease including hypertension.",
         "alias": "Cardiovascular disease including hypertension",
@@ -455,6 +475,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "COMORBIDITY",
         "name": "diabetes",
         "description": "Diabetes type 1 & type 2.",
         "alias": "diabetes",
@@ -467,6 +488,7 @@
     "fields": {
         "created_at": "2013-09-06T00:00:00+00:00",
         "updated_at": "2013-09-06T00:00:00+00:00",
+        "category": "COMORBIDITY",
         "name": "chronic_or_neuromuscular_neurological_disease",
         "description": "Chronic or neuromuscular neurological disease.",
         "alias": "Chronic or neuromuscular neurological disease",

--- a/biospecdb/apps/uploader/migrations/0001_initial.py
+++ b/biospecdb/apps/uploader/migrations/0001_initial.py
@@ -114,6 +114,7 @@ class Migration(migrations.Migration):
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('updated_at', models.DateTimeField(auto_now=True)),
+                ('category', models.CharField(choices=[('BLOODWORK', 'Bloodwork'), ('COMORBIDITY', 'Comorbidity'), ('DRUG', 'Drug'), ('PATIENT_INFO', 'Patient Info'), ('PATIENT_INFO_II', 'Patient Info Ii'), ('PATIENT_PREP', 'Patient Prep'), ('SYMPTOM', 'Symptom'), ('TEST', 'Test'), ('VITALS', 'Vitals')], max_length=128)),
                 ('name', models.CharField(max_length=128)),
                 ('description', models.CharField(max_length=256)),
                 ('alias', models.CharField(help_text='Alias column name for bulk data ingestion from .csv, etc.', max_length=128)),

--- a/biospecdb/apps/uploader/models.py
+++ b/biospecdb/apps/uploader/models.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from enum import auto
 from pathlib import Path
 import uuid
 
@@ -276,6 +277,17 @@ class Observable(ModelWithViewDependency):
         A patient's instance are stored as models.Observation
     """
 
+    class Category(TextChoices):
+        BLOODWORK = auto()
+        COMORBIDITY = auto()
+        DRUG = auto()
+        PATIENT_INFO = auto()
+        PATIENT_INFO_II = auto()
+        PATIENT_PREP = auto()
+        SYMPTOM = auto()
+        TEST = auto()
+        VITALS = auto()
+
     Types = Types
 
     sql_view_dependencies = ("uploader.models.VisitObservationsView",)
@@ -287,6 +299,7 @@ class Observable(ModelWithViewDependency):
                        models.UniqueConstraint(Lower("alias"),
                                                name="unique_alias_name")]
 
+    category = models.CharField(max_length=128, null=False, blank=False, choices=Category.choices)
     # NOTE: See above constraint for case-insensitive uniqueness.
     name = models.CharField(max_length=128)
     description = models.CharField(max_length=256)

--- a/biospecdb/apps/uploader/tests/test_forms.py
+++ b/biospecdb/apps/uploader/tests/test_forms.py
@@ -70,6 +70,7 @@ class TestDataInputForm:
         
         # Add new observable
         meningitis = Observable(
+            category=Observable.Category.COMORBIDITY,
             name='Meningitis',
             description='An inflammation of the protective membranes covering the brain and spinal cord',
             alias='meningitis',

--- a/biospecdb/apps/uploader/tests/test_models.py
+++ b/biospecdb/apps/uploader/tests/test_models.py
@@ -193,14 +193,14 @@ class TestObservable:
         assert observable.value_class == Observable.Types.FLOAT
 
     def test_name_uniqueness(self, db):
-        Observable.objects.create(name="A", description="blah", alias="a")
+        Observable.objects.create(name="A", description="blah", alias="a", category=Observable.Category.COMORBIDITY)
         with pytest.raises(IntegrityError, match="unique_observable_name"):
-            Observable.objects.create(name="a", description="blah", alias="b")
+            Observable.objects.create(name="a", description="blah", alias="b", category=Observable.Category.COMORBIDITY)
 
     def test_alias_uniqueness(self, db):
-        Observable.objects.create(name="A", description="blah", alias="a")
+        Observable.objects.create(name="A", description="blah", alias="a", category=Observable.Category.COMORBIDITY)
         with pytest.raises(IntegrityError, match="unique_alias_name"):
-            Observable.objects.create(name="b", description="blah", alias="A")
+            Observable.objects.create(name="b", description="blah", alias="A", category=Observable.Category.COMORBIDITY)
 
 
 @pytest.mark.django_db(databases=["default", "bsr"])
@@ -259,18 +259,25 @@ class TestObservation:
         visit = Visit.objects.create(patient_age=40, patient=patient)
 
         # OK.
-        observable = Observable.objects.create(name="snuffles", alias="snuffles", center=center)
+        observable = Observable.objects.create(name="snuffles",
+                                               alias="snuffles",
+                                               center=center,
+                                               category=Observable.Category.SYMPTOM)
         Observation(visit=visit, observable=observable).full_clean()
 
         # OK.
-        observable = Observable.objects.create(name="extra_snuffles", alias="extra snuffles", center=None)
+        observable = Observable.objects.create(name="extra_snuffles",
+                                               alias="extra snuffles",
+                                               center=None,
+                                               category=Observable.Category.SYMPTOM)
         Observation(visit=visit, observable=observable).full_clean()
 
         # Not OK.
         center
         observable = Observable.objects.create(name="even_more_snuffles",
-                                         alias="even more snuffles",
-                                         center=Center.objects.get(name="Imperial College London"))
+                                               alias="even more snuffles",
+                                               center=Center.objects.get(name="Imperial College London"),
+                                               category=Observable.Category.SYMPTOM)
         with pytest.raises(ValidationError, match="Patient observation observable category must belong to patient "
                                                   "center:"):
             Observation(visit=visit, observable=observable).full_clean()

--- a/biospecdb/apps/uploader/tests/test_views.py
+++ b/biospecdb/apps/uploader/tests/test_views.py
@@ -75,7 +75,7 @@ class TestViews:
             execute_sql(f"select my_new_observable from {FullPatientView._meta.db_table}", db=FullPatientView.db)
 
         # Add new observable.
-        observable = Observable(name="my_new_observable")
+        observable = Observable(name="my_new_observable", category=Observable.Category.COMORBIDITY)
         observable.clean()
         observable.save(update_view=False)
 
@@ -97,7 +97,7 @@ class TestViews:
             execute_sql(f"select my_new_observable from {FullPatientView._meta.db_table}", db=FullPatientView.db)
 
         # Add new observable.
-        Observable.objects.create(name="my_new_observable")
+        Observable.objects.create(name="my_new_observable", category=Observable.Category.SYMPTOM)
 
         # Assert that new observable exists without having updated actual view.
         execute_sql(f"select my_new_observable from {FullPatientView._meta.db_table}", db=FullPatientView.db)


### PR DESCRIPTION
Moved from #117 

Resolves [Notion ticket](https://www.notion.so/Update-model-observables-dc1991a270994165991b68aa1ae7c716?pvs=4)

In #117, it was suggested that we use fieldsets to separate these out in the form, however, it may be better to use list filters instead as is implemented in this PR. Fieldsets may look nicer, however, ``list_filter`` would still be needed, in which case, ~it's not clear to me how well they work together - might look odd.~ Momentary confusion, these are completely orthogonal since fieldsets work on fields. What would be useful is for different observation categories to be sectioned like fieldsets for the inline forms. This may also allow them to collapse.