### PR TITLE
Cast None as None in uploader.base_models.Types.cast

### DIFF
--- a/biospecdb/apps/uploader/base_models.py
+++ b/biospecdb/apps/uploader/base_models.py
@@ -38,6 +38,9 @@ class Types(TextChoices):
     FLOAT = auto()
 
     def cast(self, value):
+        if value is None:
+            return
+
         if self.name == "BOOL":
             return biospecdb.util.to_bool(value)
         elif self.name == "STR":


### PR DESCRIPTION
Fields that are allowed to be both blank and/or null require this code. 