### PR TITLE
Add nested inline forms to data admin

### DIFF
--- a/biospecdb/apps/uploader/admin.py
+++ b/biospecdb/apps/uploader/admin.py
@@ -4,6 +4,7 @@ from django.contrib import admin
 from django.db.models import Q
 from django.db.utils import OperationalError
 import django.forms as forms
+from nested_admin import NestedStackedInline, NestedTabularInline, NestedModelAdmin
 
 from .models import BioSample, Observable, Instrument, Patient, SpectralData, Observation, UploadedFile, Visit,\
     QCAnnotator, QCAnnotation, Center, get_center, BioSampleType, SpectraMeasurementType
@@ -104,7 +105,7 @@ class UploadedFileAdmin(RestrictedByCenterMixin, admin.ModelAdmin):
         return qs.filter(center=Center.objects.get(pk=request.user.center.pk))
 
 
-class QCAnnotationInline(RestrictedByCenterMixin, admin.TabularInline):
+class QCAnnotationInline(RestrictedByCenterMixin, NestedTabularInline):
     model = QCAnnotation
     extra = 0
     min_num = 1
@@ -150,7 +151,7 @@ class QCAnnotatorAdmin(RestrictedByCenterMixin, admin.ModelAdmin):
 
 
 @admin.register(Observable)
-class ObservableAdmin(RestrictedByCenterMixin, admin.ModelAdmin):
+class ObservableAdmin(RestrictedByCenterMixin, NestedModelAdmin):
     readonly_fields = ["created_at", "updated_at"]  # TODO: Might need specific user group.
     ordering = ["name"]
     search_fields = ["name"]
@@ -201,7 +202,7 @@ class ObservationInlineForm(forms.ModelForm):
             pass
 
 
-class ObservationInline(ObservationMixin, RestrictedByCenterMixin, admin.TabularInline):
+class ObservationInline(ObservationMixin, RestrictedByCenterMixin, NestedTabularInline):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         try:
@@ -229,7 +230,7 @@ class ObservationInline(ObservationMixin, RestrictedByCenterMixin, admin.Tabular
 
 
 @admin.register(Observation)
-class ObservationAdmin(ObservationMixin, RestrictedByCenterMixin, admin.ModelAdmin):
+class ObservationAdmin(ObservationMixin, RestrictedByCenterMixin, NestedModelAdmin):
     search_fields = ["observable__name", "visit__patient__patient_id", "visit__patient__patient_cid"]
     search_help_text = "Observable, Patient ID or CID"
     date_hierarchy = "updated_at"
@@ -255,7 +256,7 @@ class SpectralDataMixin:
 
 
 @admin.register(SpectralData)
-class SpectralDataAdmin(SpectralDataMixin, RestrictedByCenterMixin, admin.ModelAdmin):
+class SpectralDataAdmin(SpectralDataMixin, RestrictedByCenterMixin, NestedModelAdmin):
     search_fields = ["bio_sample__visit__patient__patient_id", "bio_sample__visit__patient__patient_cid"]
     search_help_text = "Patient ID or CID"
     readonly_fields = ["created_at", "updated_at"]  # TODO: Might need specific user group.
@@ -270,7 +271,7 @@ class SpectralDataAdmin(SpectralDataMixin, RestrictedByCenterMixin, admin.ModelA
     inlines = [QCAnnotationInline]
 
 
-class SpectralDataInline(SpectralDataMixin, RestrictedByCenterMixin, admin.StackedInline):
+class SpectralDataInline(SpectralDataMixin, RestrictedByCenterMixin, NestedStackedInline):
     model = SpectralData
     extra = 0
     min_num = 1
@@ -294,7 +295,7 @@ class BioSampleMixin:
 
 
 @admin.register(BioSample)
-class BioSampleAdmin(BioSampleMixin, RestrictedByCenterMixin, admin.ModelAdmin):
+class BioSampleAdmin(BioSampleMixin, RestrictedByCenterMixin, NestedModelAdmin):
     search_fields = ["visit__patient__patient_id", "visit__patient__patient_cid"]
     search_help_text = "Patient ID or CID"
     date_hierarchy = "updated_at"
@@ -303,11 +304,12 @@ class BioSampleAdmin(BioSampleMixin, RestrictedByCenterMixin, admin.ModelAdmin):
     inlines = [SpectralDataInline]
 
 
-class BioSampleInline(BioSampleMixin, RestrictedByCenterMixin, admin.StackedInline):
+class BioSampleInline(BioSampleMixin, RestrictedByCenterMixin, NestedStackedInline):
     model = BioSample
     extra = 0
     min_num = 1
     show_change_link = True
+    inlines = [SpectralDataInline]
 
 
 class VisitAdminForm(forms.ModelForm):
@@ -342,15 +344,16 @@ class VisitAdminMixin:
         return qs.filter(patient__center=Center.objects.get(pk=request.user.center.pk))
 
 
-class VisitInline(VisitAdminMixin, RestrictedByCenterMixin, admin.TabularInline):
+class VisitInline(VisitAdminMixin, RestrictedByCenterMixin, NestedTabularInline):
     model = Visit
     extra = 0
     min_num = 1
     show_change_link = True
+    inlines = [BioSampleInline, ObservationInline]
 
 
 @admin.register(Visit)
-class VisitAdmin(VisitAdminMixin, RestrictedByCenterMixin, admin.ModelAdmin):
+class VisitAdmin(VisitAdminMixin, RestrictedByCenterMixin, NestedModelAdmin):
     search_fields = ["patient__patient_id", "patient__patient_cid"]
     search_help_text = "Patient ID or CID"
     date_hierarchy = "updated_at"
@@ -361,7 +364,7 @@ class VisitAdmin(VisitAdminMixin, RestrictedByCenterMixin, admin.ModelAdmin):
 
 
 @admin.register(Patient)
-class PatientAdmin(RestrictedByCenterMixin, admin.ModelAdmin):
+class PatientAdmin(RestrictedByCenterMixin, NestedModelAdmin):
     search_fields = ["patient_id", "patient_cid"]
     search_help_text = "Patient ID or CID"
     readonly_fields = ["created_at", "updated_at"]  # TODO: Might need specific user group.

--- a/biospecdb/settings.py
+++ b/biospecdb/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    "nested_admin",
     "explorer",
     "uploader.apps.UploaderConfig",
     "user.apps.UserConfig"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ license = {file = "LICENSE"}
 requires-python = ">=3.11"
 dependencies = [
     "django",
+    "django-nested-admin",
     "django-sql-explorer[charts]",
     "kaleido",
     "openpyxl",

--- a/requirements/prd.txt
+++ b/requirements/prd.txt
@@ -1,4 +1,5 @@
 django==4.2.7
+django-nested-admin==4.0.2
 django-sql-explorer[charts]==3.2.1
 kaleido==0.2.1
 openpyxl==3.1.2


### PR DESCRIPTION
Resolves [Notion ticket](https://www.notion.so/Add-nested-inline-forms-to-Data-Admin-88187cd188834949b5f1fc20f99d4144?pvs=4).

This uses the 3rd party package [django-nested-admin](https://github.com/theatlantic/django-nested-admin/).

This PR supersedes #172 

Dependant on #178 

Out of the box, Django gives you inline admin forms, however, they're limited to the model's fields and the fields of any fk. It doesn't follow fks beyond the 1st layer, i.e., patient can have an inline for visit but none of visit's fk inlines. Nested inlines is needed to achieve data collection from a single admin page/form (without having to write this ourselves).
![nested-inlines](https://github.com/ssec-jhu/biospecdb/assets/5013975/7d41e23f-be84-45fc-8356-eabac4192128)


