### PR TITLE
Check against null self.data.name rather than self.data

### DIFF
--- a/biospecdb/apps/uploader/models.py
+++ b/biospecdb/apps/uploader/models.py
@@ -514,7 +514,9 @@ class SpectralData(DatedModel):
 
             The schema is equivalent to `json.dumps(dataclasses.asdict(uploader.io.SpectralData))``.
         """
-        if self.data is None:
+
+        # Note: self.data is a FieldFile and is never None so check is "empty" instead, i.e., self.data.name is None.
+        if not self.data:
             return
 
         try:

--- a/biospecdb/apps/uploader/tests/test_models.py
+++ b/biospecdb/apps/uploader/tests/test_models.py
@@ -296,6 +296,14 @@ class TestSpectralData:
         for obj in SpectralData.objects.all():
             assert Path(obj.data.name).exists()
 
+    def test_no_file_validation(self, db):
+        """ Test that a validation error is raised rather than any other python exception which would indicate a bug.
+            See https://github.com/ssec-jhu/biospecdb/pull/181
+        """
+        data = SpectralData()
+        with pytest.raises(ValidationError):
+            data.full_clean()
+
     def test_temp_files_deleted(self, mock_data_from_files):
         n_patients = 10
         assert len(SpectralData.objects.all()) == n_patients


### PR DESCRIPTION
The following exception was raised instead of a validation error:
```python
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../../../django/django/db/models/base.py:1477: in full_clean
    self.clean()
../models.py:538: in clean
    if (cleaned_file := self.clean_data_file()) is not None:
../models.py:523: in clean_data_file
    data = uploader.io.read_spectral_data(self.data)
../io.py:265: in read_spectral_data
    _fp, filename = _get_file_info(file)
../io.py:291: in _get_file_info
    fp = file.file
../../../../../django/django/db/models/fields/files.py:46: in _get_file
    self._require_file()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <FieldFile: None>

    def _require_file(self):
        if not self:
>           raise ValueError(
                "The '%s' attribute has no file associated with it." % self.field.name
            )
E           ValueError: The 'data' attribute has no file associated with it.

../../../../../django/django/db/models/fields/files.py:41: ValueError
```