### PR TITLE
Run annotator for new annotation on save and not clean

### DIFF
--- a/biospecdb/apps/uploader/models.py
+++ b/biospecdb/apps/uploader/models.py
@@ -788,9 +788,12 @@ class QCAnnotation(DatedModel):
 
         return self.value
 
-    def clean(self):
-        super().clean()
-        self.run()
+    def save(self, *args, **kwargs):
+        self.run(save=False)
+        super().save(*args, **kwargs)
+
+    def asave(self, *args, **kwargs):
+        raise NotImplementedError
 
 
 def get_center(obj):

--- a/biospecdb/apps/uploader/tests/test_qc_models.py
+++ b/biospecdb/apps/uploader/tests/test_qc_models.py
@@ -203,11 +203,18 @@ class TestQCFunctionality:
         for expected_results, annotation in zip(self.expected_sum_results, QCAnnotation.objects.all()):
             assert pytest.approx(annotation.get_value()) == expected_results
 
-    def test_no_file_validation(self, db):
+    def test_no_file_validation(self, qcannotators):
         """ Test that a validation error is raised rather than any other python exception which would indicate a bug.
             See https://github.com/ssec-jhu/biospecdb/pull/182
         """
-        annotation = QCAnnotation()
+        annotation = QCAnnotation(annotator=QCAnnotator.objects.get(name="sum"))
         with pytest.raises(ValidationError):
             annotation.full_clean()
+
+    def test_no_file_related_error(self, qcannotators):
+        """ Test that a validation error is raised rather than any other python exception which would indicate a bug.
+            See https://github.com/ssec-jhu/biospecdb/pull/182
+        """
+        annotation = QCAnnotation(annotator=QCAnnotator.objects.get(name="sum"))
+        with pytest.raises(QCAnnotation.spectral_data.RelatedObjectDoesNotExist):
             annotation.save()

--- a/biospecdb/apps/uploader/tests/test_qc_models.py
+++ b/biospecdb/apps/uploader/tests/test_qc_models.py
@@ -39,6 +39,7 @@ class TestQCFunctionality:
         annotation = QCAnnotation(annotator=annotator, spectral_data=spectral_data)
         assert annotation.value is None
         annotation.full_clean()
+        annotation.save()
         assert pytest.approx(float(annotation.value)) == 915.3270367661034
 
     expected_sum_results = [915.3270367661034,
@@ -201,3 +202,12 @@ class TestQCFunctionality:
         call_command("run_qc_annotators", "--no_reruns")
         for expected_results, annotation in zip(self.expected_sum_results, QCAnnotation.objects.all()):
             assert pytest.approx(annotation.get_value()) == expected_results
+
+    def test_no_file_validation(self, db):
+        """ Test that a validation error is raised rather than any other python exception which would indicate a bug.
+            See https://github.com/ssec-jhu/biospecdb/pull/182
+        """
+        annotation = QCAnnotation()
+        with pytest.raises(ValidationError):
+            annotation.full_clean()
+            annotation.save()

--- a/biospecdb/settings.py
+++ b/biospecdb/settings.py
@@ -208,7 +208,8 @@ EXPLORER_DATA_EXPORTERS_ALLOW_DATA_FILE_ALIAS = False
 
 # Custom settings:
 
-# Automatically run "default" annotators when new spectral data is added.
+# Automatically run "default" annotators when new spectral data is saved. Note: Annotators are always run when new
+# annotations are explicitly created and saved regardless of the below setting.
 AUTO_ANNOTATE = True
 
 # Run newly added/updated annotator on all spectral data if annotator.default is True.


### PR DESCRIPTION
The following exception was raised instead of a validation error:
```python
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../../../django/django/db/models/base.py:1477: in full_clean
    self.clean()
../models.py:538: in clean
    if (cleaned_file := self.clean_data_file()) is not None:
../models.py:523: in clean_data_file
    data = uploader.io.read_spectral_data(self.data)
../io.py:265: in read_spectral_data
    _fp, filename = _get_file_info(file)
../io.py:291: in _get_file_info
    fp = file.file
../../../../../django/django/db/models/fields/files.py:46: in _get_file
    self._require_file()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <FieldFile: None>

    def _require_file(self):
        if not self:
>           raise ValueError(
                "The '%s' attribute has no file associated with it." % self.field.name
            )
E           ValueError: The 'data' attribute has no file associated with it.

../../../../../django/django/db/models/fields/files.py:41: ValueError
```

Related to #181 