### PR TITLE
Admin tweaks

### DIFF
--- a/biospecdb/apps/uploader/admin.py
+++ b/biospecdb/apps/uploader/admin.py
@@ -107,9 +107,13 @@ class UploadedFileAdmin(RestrictedByCenterMixin, admin.ModelAdmin):
 
 class QCAnnotationInline(RestrictedByCenterMixin, NestedTabularInline):
     model = QCAnnotation
-    extra = 0
+    extra = 1
     min_num = 0
     show_change_link = True
+
+    def get_extra(self, request, obj=None, **kwargs):
+        # Only display inlines for those that exist, i.e., no expanded extras (if they exist).
+        return 0 if obj and obj.pk and obj.qc_annotation.count() else self.extra
 
 
 @admin.register(QCAnnotation)
@@ -218,10 +222,9 @@ class ObservationInline(ObservationMixin, RestrictedByCenterMixin, NestedTabular
     fk_name = "visit"
 
     def get_extra(self, request, obj=None, **kwargs):
-        if obj and obj.pk:
+        if obj and obj.pk and obj.observation.count():
             # Only display inlines for those that exist, i.e., no extras (when self.extra=0).
-            if len(obj.observation.all()):
-                extra = self.extra
+            extra = self.extra
         else:
             # Note: Calling ``len(self.formfield_for_foreignkey(db_field, request)`` would be better, however, it's not
             # clear how to correctly pass ``db_field``. The following was copied from
@@ -279,10 +282,14 @@ class SpectralDataAdminWithInlines(SpectralDataAdmin):
 
 class SpectralDataInline(SpectralDataMixin, RestrictedByCenterMixin, NestedStackedInline):
     model = SpectralData
-    extra = 0
+    extra = 1
     min_num = 0
     show_change_link = True
     fk_name = "bio_sample"
+
+    def get_extra(self, request, obj=None, **kwargs):
+        # Only display inlines for those that exist, i.e., no expanded extras (if they exist).
+        return 0 if obj and obj.pk and obj.spectral_data.count() else self.extra
 
 
 class BioSampleMixin:
@@ -316,11 +323,15 @@ class BioSampleAdminWithInlines(BioSampleAdmin):
 
 class BioSampleInline(BioSampleMixin, RestrictedByCenterMixin, NestedStackedInline):
     model = BioSample
-    extra = 0
+    extra = 1
     min_num = 0
     show_change_link = True
     fk_name = "visit"
     inlines = [SpectralDataInline]
+
+    def get_extra(self, request, obj=None, **kwargs):
+        # Only display inlines for those that exist, i.e., no expanded extras (if they exist).
+        return 0 if obj and obj.pk and obj.bio_sample.count() else self.extra
 
 
 class VisitAdminForm(forms.ModelForm):
@@ -357,11 +368,15 @@ class VisitAdminMixin:
 
 class VisitInline(VisitAdminMixin, RestrictedByCenterMixin, NestedTabularInline):
     model = Visit
-    extra = 0
+    extra = 1
     min_num = 0
     show_change_link = True
     fk_name = "patient"
     inlines = [BioSampleInline, ObservationInline]
+
+    def get_extra(self, request, obj=None, **kwargs):
+        # Only display inlines for those that exist, i.e., no expanded extras (if they exist).
+        return 0 if obj and obj.pk and obj.visit.count() else self.extra
 
 
 @admin.register(Visit)

--- a/biospecdb/apps/uploader/admin.py
+++ b/biospecdb/apps/uploader/admin.py
@@ -108,7 +108,7 @@ class UploadedFileAdmin(RestrictedByCenterMixin, admin.ModelAdmin):
 class QCAnnotationInline(RestrictedByCenterMixin, NestedTabularInline):
     model = QCAnnotation
     extra = 0
-    min_num = 1
+    min_num = 0
     show_change_link = True
 
 
@@ -215,18 +215,21 @@ class ObservationInline(ObservationMixin, RestrictedByCenterMixin, NestedTabular
     extra = 0
     model = Observation
     show_change_link = True
+    fk_name = "visit"
 
-    def get_min_num(self, request, obj=None, **kwargs):
+    def get_extra(self, request, obj=None, **kwargs):
         if obj and obj.pk:
-            min_num = len(obj.observation.all())
+            # Only display inlines for those that exist, i.e., no extras (when self.extra=0).
+            if len(obj.observation.all()):
+                extra = self.extra
         else:
             # Note: Calling ``len(self.formfield_for_foreignkey(db_field, request)`` would be better, however, it's not
             # clear how to correctly pass ``db_field``. The following was copied from
             # ``RestrictedByCenterMixin.formfield_for_foreignkey``.
             center = Center.objects.get(pk=request.user.center.pk)
-            min_num = len(Observable.objects.filter(Q(center=center) | Q(center=None)))
+            extra = len(Observable.objects.filter(Q(center=center) | Q(center=None)))
 
-        return min_num
+        return extra
 
 
 @admin.register(Observation)
@@ -268,14 +271,18 @@ class SpectralDataAdmin(SpectralDataMixin, RestrictedByCenterMixin, NestedModelA
                    "bio_sample__sample_type",
                    "bio_sample__sample_processing",
                    "bio_sample__visit__patient__gender")
+
+
+class SpectralDataAdminWithInlines(SpectralDataAdmin):
     inlines = [QCAnnotationInline]
 
 
 class SpectralDataInline(SpectralDataMixin, RestrictedByCenterMixin, NestedStackedInline):
     model = SpectralData
     extra = 0
-    min_num = 1
+    min_num = 0
     show_change_link = True
+    fk_name = "bio_sample"
 
 
 class BioSampleMixin:
@@ -301,14 +308,18 @@ class BioSampleAdmin(BioSampleMixin, RestrictedByCenterMixin, NestedModelAdmin):
     date_hierarchy = "updated_at"
     list_filter = ("visit__patient__center", "sample_type", "sample_processing")
     list_display = ["patient_id", "sample_type"]
+
+
+class BioSampleAdminWithInlines(BioSampleAdmin):
     inlines = [SpectralDataInline]
 
 
 class BioSampleInline(BioSampleMixin, RestrictedByCenterMixin, NestedStackedInline):
     model = BioSample
     extra = 0
-    min_num = 1
+    min_num = 0
     show_change_link = True
+    fk_name = "visit"
     inlines = [SpectralDataInline]
 
 
@@ -347,8 +358,9 @@ class VisitAdminMixin:
 class VisitInline(VisitAdminMixin, RestrictedByCenterMixin, NestedTabularInline):
     model = Visit
     extra = 0
-    min_num = 1
+    min_num = 0
     show_change_link = True
+    fk_name = "patient"
     inlines = [BioSampleInline, ObservationInline]
 
 
@@ -360,6 +372,9 @@ class VisitAdmin(VisitAdminMixin, RestrictedByCenterMixin, NestedModelAdmin):
     list_filter = ("patient__center",)
     # autocomplete_fields = ["previous_visit"]  # Conflicts with VisitAdminForm queryset.
     list_display = ["patient_id", "visit_count", "gender", "previous_visit"]
+
+
+class VisitAdminWithInlines(VisitAdmin):
     inlines = [BioSampleInline, ObservationInline]
 
 
@@ -372,7 +387,6 @@ class PatientAdmin(RestrictedByCenterMixin, NestedModelAdmin):
     ordering = ("-updated_at",)
     list_filter = ("center", "gender")
     list_display = ["patient_id", "patient_cid", "gender", "age", "visit_count", "center"]
-    inlines = [VisitInline]
 
     @admin.display
     def age(self, obj):
@@ -391,6 +405,11 @@ class PatientAdmin(RestrictedByCenterMixin, NestedModelAdmin):
         if request.user.is_superuser:
             return qs
         return qs.filter(center=Center.objects.get(pk=request.user.center.pk))
+
+
+class PatientAdminWithInlines(PatientAdmin):
+    inlines = [VisitInline]
+
 
 # NOTE: The following admin can be used to visually sanity check that changes by user.models.Center to the "default" DB
 # get reflected in the "bsr" DB. We never want uploader.models.Center to be editable by any admin page, so we restrict
@@ -422,15 +441,32 @@ class DataAdminSite(admin.AdminSite):
     index_title = "Data Administration"
     site_title = index_title
 
+    model_order = [Patient,
+                   Visit,
+                   Observation,
+                   BioSample,
+                   SpectralData,
+                   UploadedFile
+                   ]
+
+    def get_app_list(self, request, app_label=None):
+        app_list = super().get_app_list(request, app_label=app_label)
+
+        if hasattr(self, "model_order"):
+            for app in app_list:
+                app["models"].sort(key=lambda x: self.model_order.index(x["model"]))
+
+        return app_list
+
 
 data_admin = DataAdminSite(name="data_admin")
-data_admin.register(Patient, admin_class=PatientAdmin)
-data_admin.register(Visit, admin_class=VisitAdmin)
+data_admin.register(Patient, admin_class=PatientAdminWithInlines)
+data_admin.register(Visit, admin_class=VisitAdminWithInlines)
 data_admin.register(Observation, admin_class=ObservationAdmin)
-data_admin.register(BioSample, admin_class=BioSampleAdmin)
-data_admin.register(SpectralData, admin_class=SpectralDataAdmin)
+data_admin.register(BioSample, admin_class=BioSampleAdminWithInlines)
+data_admin.register(SpectralData, admin_class=SpectralDataAdminWithInlines)
 data_admin.register(UploadedFile, admin_class=UploadedFileAdmin)
-data_admin.register(Instrument, admin_class=InstrumentAdmin)
-data_admin.register(QCAnnotation, admin_class=QCAnnotationAdmin)
-data_admin.register(QCAnnotator, admin_class=QCAnnotatorAdmin)
-data_admin.register(Observable, admin_class=ObservableAdmin)
+# data_admin.register(Instrument, admin_class=InstrumentAdmin)
+# data_admin.register(QCAnnotation, admin_class=QCAnnotationAdmin)
+# data_admin.register(QCAnnotator, admin_class=QCAnnotatorAdmin)
+# data_admin.register(Observable, admin_class=ObservableAdmin)

--- a/biospecdb/apps/uploader/tests/test_uploader_admin.py
+++ b/biospecdb/apps/uploader/tests/test_uploader_admin.py
@@ -7,6 +7,7 @@ from django.test import Client
 import pytest
 
 from user.models import BaseCenter, Center as UserCenter
+from uploader.admin import DataAdminSite
 from uploader.base_models import DatedModel, SqlView, ModelWithViewDependency
 import uploader.models
 
@@ -74,7 +75,7 @@ class TestAdminPage:
     def test_admin_pages(self, request, user, url_root, model, action):
         user = request.getfixturevalue(user)
 
-        if url_root == "/data/uploader/" and model in SKIP_MODELS:
+        if url_root == "/data/uploader/" and model not in DataAdminSite.model_order:
             pytest.skip("Model not registered with data admin site.")
 
         if model in SKIP_MODELS and not user.is_superuser:
@@ -91,7 +92,7 @@ class TestAdminPage:
     @pytest.mark.parametrize("url_root", ("/data/uploader/", "/admin/uploader/"))
     @pytest.mark.parametrize("model", uploader_models)
     def test_admin_view_perms_pages(self, with_perm, staffuser, url_root, model, mock_data):
-        if url_root == "/data/uploader/" and model in SKIP_MODELS:
+        if url_root == "/data/uploader/" and model not in DataAdminSite.model_order:
             pytest.skip("Model not registered with data admin site.")
 
         c = Client()
@@ -106,7 +107,8 @@ class TestAdminPage:
     @pytest.mark.parametrize("url_root", ("/data/uploader/", "/admin/uploader/"))
     @pytest.mark.parametrize("model", uploader_models)
     def test_admin_add_perms_pages(self, with_perm, staffuser, url_root, model):
-        if url_root == "/data/uploader/" and model in SKIP_MODELS:
+
+        if url_root == "/data/uploader/" and model not in DataAdminSite.model_order:
             pytest.skip("Model not registered with data admin site.")
 
         c = Client()
@@ -119,9 +121,10 @@ class TestAdminPage:
 
     @pytest.mark.parametrize("with_perm", (True, False))
     @pytest.mark.parametrize("model", uploader_models)
-    def test_admin_change_perms_pages(self, with_perm, staffuser, model, mock_data, qcannotators):
-        if model in SKIP_MODELS:
-            pytest.skip("Model edits restricted to superuser")
+    @pytest.mark.parametrize("url_root", ("/data/uploader/", "/admin/uploader/"))
+    def test_admin_change_perms_pages(self, with_perm, url_root, staffuser, model, mock_data, qcannotators):
+        if url_root == "/data/uploader/" and model not in DataAdminSite.model_order:
+            pytest.skip("Model not registered with data admin site.")
 
         if model in (uploader.models.QCAnnotation, uploader.models.UploadedFile):
             pytest.skip("This data doesn't exist in mock_data fixture.")
@@ -132,16 +135,18 @@ class TestAdminPage:
         c.force_login(staffuser)
 
         for obj in model.objects.all():
-            url = f"/data/uploader/{model_name}/{obj.pk}/change/"
+            url = f"{url_root}{model_name}/{obj.pk}/change/"
             response = c.get(url, follow=with_perm)
             expected_resp_code = 200 if with_perm else 403
             assert response.status_code == expected_resp_code
 
     @pytest.mark.parametrize("with_perm", (True, False))
     @pytest.mark.parametrize("model", uploader_models)
-    def test_admin_delete_perms_pages(self, with_perm, staffuser, model, mock_data, qcannotators):
-        if model in SKIP_MODELS:
-            pytest.skip("Model edits restricted to superuser")
+    @pytest.mark.parametrize("url_root", ("/data/uploader/", "/admin/uploader/"))
+    def test_admin_delete_perms_pages(self, with_perm, url_root, staffuser, model, mock_data, qcannotators):
+
+        if url_root == "/data/uploader/" and model not in DataAdminSite.model_order:
+            pytest.skip("Model not registered with data admin site.")
 
         if model in (uploader.models.QCAnnotation, uploader.models.UploadedFile):
             pytest.skip("This data doesn't exist in mock_data fixture.")
@@ -152,7 +157,7 @@ class TestAdminPage:
         c.force_login(staffuser)
 
         for obj in model.objects.all():
-            url = f"/data/uploader/{model_name}/{obj.pk}/delete/"
+            url = f"{url_root}{model_name}/{obj.pk}/delete/"
             response = c.get(url, follow=with_perm)
             expected_resp_code = 200 if with_perm else 403
             assert response.status_code == expected_resp_code


### PR DESCRIPTION
The following two changes effectively make inlines "collapsable"/optional.
 * ``min_num = 0``
 * ~``extra = 0``~ PI prefers these to be expanded by default.
 
* Only display the number of given existing observations or an extra equal to the total applicable observables.
* Don't use any inlines for admin pages, do so only for the data admin pages.
* Exclude the following from the data admin pages:
  * Instrument
  * Observable
  * QCAnnotator
  * QCAnnotation