### PR TITLE
Filter only existing bool pie chart data

### DIFF
--- a/biospecdb/apps/uploader/charts.py
+++ b/biospecdb/apps/uploader/charts.py
@@ -26,7 +26,11 @@ def count_bool_observables(result: "QueryResult"):  # noqa: F821
 
     bool_observables = [d.name for d in Observable.objects.all() if d.value_class == "BOOL"]
     df = pd.DataFrame(result.data, columns=result.header_strings)
-    df = df[bool_observables].replace({"True": True, "False": False})
+    cols = set(bool_observables) & set(df.columns)
+    if not cols:
+        return
+    df = df[list(cols)]
+    df.replace({"True": True, "False": False}, inplace=True)
     return df.sum()
 
 

--- a/biospecdb/apps/uploader/tests/test_charts.py
+++ b/biospecdb/apps/uploader/tests/test_charts.py
@@ -37,13 +37,6 @@ class TestCharts:
     def test_empty_get_line_chart(self, query):
         assert get_line_chart(query) is None
 
-    def test_get_pie_chart_exceptions(self, monkeypatch, mock_data_from_files, query):
-        assert get_pie_chart(query) is None
-
-        monkeypatch.setattr(settings, "DEBUG", True)
-        with pytest.raises(KeyError):
-            get_pie_chart(query)
-
     def test_get_line_chart_exceptions(self, monkeypatch, mock_data_from_files, query):
         assert get_line_chart(query) is None
 


### PR DESCRIPTION
``count_bool_observables`` shouldn't fail even if some cols exist but not all.