### PR TITLE
Bulk upload: find existing patient against CID AND center, not just CID

### DIFF
--- a/biospecdb/apps/uploader/loaddata.py
+++ b/biospecdb/apps/uploader/loaddata.py
@@ -56,8 +56,10 @@ def save_data_to_db(meta_data, spectral_data, center=None, joined_data=None, dry
                     patient = Patient.objects.get(pk=index)
                 except (Patient.DoesNotExist, ValidationError):
                     try:
-                        # Allow patients to be referenced by both patient_id and patient_cid.
-                        patient = Patient.objects.get(patient_cid=index)
+                        # Allow patients to be referenced by both patient_id and patient_cid, i.e., assume that the
+                        # "patient ID" provided could actually be the patient CID.
+                        # Note: patient_cid is only guaranteed to be unique to a center and not by itself.
+                        patient = Patient.objects.get(patient_cid=index, center=center)
                     except (Patient.DoesNotExist, ValidationError):
                         # NOTE: We do not use the ``index`` read from file as the pk even if it is a UUID. The above
                         # ``get()`` only allows for existing patients to be re-used when _already_ in the db with their

--- a/biospecdb/apps/uploader/tests/test_models.py
+++ b/biospecdb/apps/uploader/tests/test_models.py
@@ -14,7 +14,7 @@ from uploader.loaddata import save_data_to_db
 from user.models import Center as UserCenter
 from uploader.models import Center as UploaderCenter
 import biospecdb.util
-from uploader.tests.conftest import DATA_PATH
+from uploader.tests.conftest import bulk_upload, DATA_PATH
 
 
 @pytest.mark.django_db(databases=["default", "bsr"])
@@ -453,6 +453,41 @@ class TestUploadedFile:
                                                                                  name=spectral_file_path.name))
             with pytest.raises(ValidationError, match="Patient ID mismatch."):
                 data_upload.clean()
+
+    def test_re_upload(self, django_db_blocker, observables, instruments, mock_data_from_files):
+        n_patients = 10
+        assert UploadedFile.objects.count() == 1
+        assert Patient.objects.count() == n_patients
+        assert Visit.objects.count() == n_patients
+
+        with django_db_blocker.unblock():
+            bulk_upload()
+
+        assert UploadedFile.objects.count() == 2
+        assert Patient.objects.count() == n_patients
+        assert Visit.objects.count() == n_patients * 2
+
+    def test_upload_on_cid(self, django_db_blocker, observables, instruments, mock_data_from_files):
+        n_patients = 10
+        assert UploadedFile.objects.count() == 1
+        assert Patient.objects.count() == n_patients
+        assert Visit.objects.count() == n_patients
+
+        # copy patients
+        for patient in Patient.objects.select_related("center").all():
+            new_patient = Patient(patient_cid=patient.patient_id, gender=patient.gender, center=patient.center)
+            patient.delete()
+            new_patient.full_clean()
+            new_patient.save()
+
+        assert Patient.objects.count() == n_patients
+
+        with django_db_blocker.unblock():
+            bulk_upload()
+
+        assert UploadedFile.objects.count() == 2
+        assert Patient.objects.count() == n_patients * 1
+        assert Visit.objects.count() == n_patients * 1
 
 
 @pytest.mark.django_db(databases=["default", "bsr"])

--- a/biospecdb/apps/uploader/tests/test_models.py
+++ b/biospecdb/apps/uploader/tests/test_models.py
@@ -497,7 +497,6 @@ class TestUploadedFile:
         assert Visit.objects.count() == 0
 
         # Re-ingest data.
-        # with django_db_blocker.unblock():
         bulk_upload()
 
         assert UploadedFile.objects.count() == 2


### PR DESCRIPTION
Resolves [Notion ticket](https://www.notion.so/Bulk-upload-ingestion-should-search-for-existing-patient-against-patient_cid-AND-center-0f4b72c31ddb4cfe9ce7d08ce0c300d5?pvs=4).

Relates to [patient_id vs CID for bulk upload](https://www.notion.so/patient_id-vs-CID-for-bulk-upload-c3f7a3f7d4cb430393329a1694291671?pvs=4)