### PR TITLE
Refactor model bulk upload parsing

### DIFF
--- a/biospecdb/apps/uploader/models.py
+++ b/biospecdb/apps/uploader/models.py
@@ -159,7 +159,7 @@ class Patient(DatedModel):
     center = models.ForeignKey(Center, null=False, blank=False, on_delete=models.PROTECT)
 
     @classmethod
-    def parse_fields_from_pandas_series(cls, series, index=None):
+    def parse_fields_from_pandas_series(cls, series):
         """ Parse the pandas series for field values returning a dict. """
         gender = series.get(cls.gender.field.verbose_name.lower(), None)
         gender = cls.Gender(gender)
@@ -203,7 +203,7 @@ class Visit(DatedModel):
                                       verbose_name="Age")
 
     @classmethod
-    def parse_fields_from_pandas_series(cls, series, index=None):
+    def parse_fields_from_pandas_series(cls, series):
         """ Parse the pandas series for field values returning a dict. """
         patient_age = series.get(cls.patient_age.field.verbose_name.lower(), None)
         return dict(patient_age=patient_age)
@@ -416,7 +416,7 @@ class Instrument(DatedModel):
     center = models.ForeignKey(Center, null=True, blank=True, on_delete=models.PROTECT)
 
     @classmethod
-    def parse_fields_from_pandas_series(cls, series, index=None):
+    def parse_fields_from_pandas_series(cls, series):
         """ Parse the pandas series for field values returning a dict. """
         spectrometer = series.get(cls.spectrometer.field.verbose_name.lower(), None)
         atr_crystal = series.get(cls.atr_crystal.field.verbose_name.lower(), None)
@@ -455,7 +455,7 @@ class BioSample(DatedModel):
     thawing_time = models.IntegerField(blank=True, null=True, verbose_name="Thawing time")
 
     @classmethod
-    def parse_fields_from_pandas_series(cls, series, index=None):
+    def parse_fields_from_pandas_series(cls, series):
         """ Parse the pandas series for field values returning a dict. """
         sample_type = lower(series.get(cls.sample_type.field.verbose_name.lower(), None))
         sample_type = get_object_or_raise_validation(BioSampleType, name=sample_type)
@@ -517,7 +517,7 @@ class SpectralData(DatedModel):
                             verbose_name="Spectral data file")
 
     @classmethod
-    def parse_fields_from_pandas_series(cls, series, index=None):
+    def parse_fields_from_pandas_series(cls, series):
         """ Parse the pandas series for field values returning a dict. """
         spectra_measurement = lower(series.get(cls.spectra_measurement.field.verbose_name.lower(), None))
         spectra_measurement = get_object_or_raise_validation(SpectraMeasurementType, name=spectra_measurement)

--- a/biospecdb/apps/uploader/models.py
+++ b/biospecdb/apps/uploader/models.py
@@ -13,7 +13,7 @@ from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 import pandas as pd
 
-from biospecdb.util import get_object_or_raise_validation, is_valid_uuid, lower, to_uuid
+from biospecdb.util import get_field_value, get_object_or_raise_validation, is_valid_uuid, lower, to_uuid
 from biospecdb.qc.qcfilter import QcFilter
 import uploader.io
 from uploader.loaddata import save_data_to_db
@@ -161,7 +161,7 @@ class Patient(DatedModel):
     @classmethod
     def parse_fields_from_pandas_series(cls, series):
         """ Parse the pandas series for field values returning a dict. """
-        gender = series.get(cls.gender.field.verbose_name.lower(), None)
+        gender = get_field_value(series, cls, "gender")
         gender = cls.Gender(gender)
         return dict(gender=gender)
 
@@ -205,8 +205,7 @@ class Visit(DatedModel):
     @classmethod
     def parse_fields_from_pandas_series(cls, series):
         """ Parse the pandas series for field values returning a dict. """
-        patient_age = series.get(cls.patient_age.field.verbose_name.lower(), None)
-        return dict(patient_age=patient_age)
+        return dict(patient_age=get_field_value(series, cls, "patient_age"))
 
     def clean(self):
         """ Model validation. """
@@ -418,9 +417,8 @@ class Instrument(DatedModel):
     @classmethod
     def parse_fields_from_pandas_series(cls, series):
         """ Parse the pandas series for field values returning a dict. """
-        spectrometer = series.get(cls.spectrometer.field.verbose_name.lower(), None)
-        atr_crystal = series.get(cls.atr_crystal.field.verbose_name.lower(), None)
-        return dict(spectrometer__iexact=spectrometer, atr_crystal__iexact=atr_crystal)
+        return dict(spectrometer__iexact=get_field_value(series, cls, "spectrometer"),
+                    atr_crystal__iexact=get_field_value(series, cls, "atr_crystal"))
 
     def __str__(self):
         return f"{self.spectrometer}_{self.atr_crystal}"
@@ -457,15 +455,12 @@ class BioSample(DatedModel):
     @classmethod
     def parse_fields_from_pandas_series(cls, series):
         """ Parse the pandas series for field values returning a dict. """
-        sample_type = lower(series.get(cls.sample_type.field.verbose_name.lower(), None))
+        sample_type = lower(get_field_value(series, cls, "sample_type"))
         sample_type = get_object_or_raise_validation(BioSampleType, name=sample_type)
-        sample_processing = series.get(cls.sample_processing.field.verbose_name.lower(), None)
-        freezing_temp = series.get(cls.freezing_temp.field.verbose_name.lower(), None)
-        thawing_time = series.get(cls.thawing_time.field.verbose_name.lower(), None)
         return dict(sample_type=sample_type,
-                    sample_processing=sample_processing,
-                    freezing_temp=freezing_temp,
-                    thawing_time=thawing_time)
+                    sample_processing=get_field_value(series, cls, "sample_processing"),
+                    freezing_temp=get_field_value(series, cls, "freezing_temp"),
+                    thawing_time=get_field_value(series, cls, "thawing_time"))
 
     @property
     def center(self):
@@ -519,15 +514,12 @@ class SpectralData(DatedModel):
     @classmethod
     def parse_fields_from_pandas_series(cls, series):
         """ Parse the pandas series for field values returning a dict. """
-        spectra_measurement = lower(series.get(cls.spectra_measurement.field.verbose_name.lower(), None))
+        spectra_measurement = lower(get_field_value(series, cls, "spectra_measurement"))
         spectra_measurement = get_object_or_raise_validation(SpectraMeasurementType, name=spectra_measurement)
-        acquisition_time = series.get(cls.acquisition_time.field.verbose_name.lower(), None)
-        n_coadditions = series.get(cls.n_coadditions.field.verbose_name.lower(), None)
-        resolution = series.get(cls.resolution.field.verbose_name.lower(), None)
         return dict(spectra_measurement=spectra_measurement,
-                    acquisition_time=acquisition_time,
-                    n_coadditions=n_coadditions,
-                    resolution=resolution)
+                    acquisition_time=get_field_value(series, cls, "acquisition_time"),
+                    n_coadditions=get_field_value(series, cls, "n_coadditions"),
+                    resolution=get_field_value(series, cls, "resolution"))
 
     @property
     def center(self):

--- a/biospecdb/util.py
+++ b/biospecdb/util.py
@@ -113,3 +113,7 @@ def get_object_or_raise_validation(obj, **kwargs):
         return obj.objects.get(**kwargs)
     except obj.DoesNotExist:
         raise ValidationError(_("%(name)s does not exist"), params=dict(name=obj.__name__))
+
+
+def get_field_value(series, obj, field, default=None):
+    return series.get(getattr(obj, field).field.verbose_name.lower(), default=default)

--- a/biospecdb/util.py
+++ b/biospecdb/util.py
@@ -4,6 +4,8 @@ import os
 from pathlib import Path
 from uuid import UUID
 
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
 import numpy as np
 import pandas as pd
 
@@ -98,3 +100,16 @@ def is_valid_uuid(value):
         except (AttributeError, ValueError):
             return False
     return True
+
+
+def lower(value):
+    if hasattr(value, "lower"):
+        value = value.lower()
+    return value
+
+
+def get_object_or_raise_validation(obj, **kwargs):
+    try:
+        return obj.objects.get(**kwargs)
+    except obj.DoesNotExist:
+        raise ValidationError(_("%(name)s does not exist"), params=dict(name=obj.__name__))


### PR DESCRIPTION
Add ``parse_fields_from_pandas_series()`` to models to better contain parsing logic used when ingesting bulk uploaded data.

Note: The usage/design isn't necessarily complete in that all fields are returned or that they're returned exactly by name, e.g., ``__iexact`` may be appended to the field key. It's at least neater than it was.

```python
class MyDjangoModel(models.Model):
    @classmethod
    def parse_fields_from_pandas_series(cls, series):
        """ Parse the pandas series for field values returning a dict. """
        ...

MyDjangoModel.objects.create(**MyDjangoModel.parse_fields_from_pandas_series(row_data))
```

This is in prep for #200 as ``loaddata.save_data_to_db()`` started to look unwieldy.