### PR TITLE
List observables by category in inline forms plus other admin tweaks

### DIFF
--- a/biospecdb/apps/uploader/admin.py
+++ b/biospecdb/apps/uploader/admin.py
@@ -273,6 +273,8 @@ class ObservationInlineForm(forms.ModelForm):
             widget = forms.NumberInput()
         elif value_class is Observable.Types.STR:
             widget = forms.TextInput()
+        else:
+            raise NotImplementedError(f"Dev error: missing widget mapping for type '{value_class}'.")
         return widget
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Resolves [Notion ticket](https://www.notion.so/Fieldsets-for-observable-catagories-for-inline-patient-form-bf54b01269284cc2b3ac163a699bf236?pvs=4).

This also dynamically uses the correct input widget for ``Observation.observable_value`` based on ``Observation.observable.value_class``.
