### PR TITLE
Gunicorn, nginx, and (semi) prd deployment

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,4 @@ omit =
     biospecdb/apps/dash/*
     biospecdb/asgi.py
     biospecdb/wsgi.py
+    biospecdb/settings/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,6 @@ db
 spectral_data
 raw_data
 datasets
+log
+run
+static

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cython_debug/
 raw_data/
 spectral_data/
 datasets/
+log/
+run/
+static/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,6 @@ RUN pip3 install -r requirements.txt
 
 COPY manage.py /app/
 COPY biospecdb/ /app/biospecdb/
+COPY config/ /app/config/
 
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -41,15 +41,21 @@ For additional cmds see the [Conda cheat-sheet](https://docs.conda.io/projects/c
 
 ### Run:
 
-  #### using Docker:
+  #### using Docker (for production):
   * Download & install Docker - see [Docker install docs](https://docs.docker.com/get-docker/).
   * ``cd`` into repo dir.
-  * Build and run with ``DJANGO_SUPERUSER_PASSWORD=admin docker compose up``
+  * Setup env vars:
+    * ``export DJANGO_SUPERUSER_PASSWORD=admin``
+    * ``source scripts/prd/gen_secret_key.sh``
+  * Build and run with ``docker compose up``, add ``-d`` to run in the background.
   * Alternatively, images can be pulled from ``ghcr.io/ssec-jhu/`` e.g., ``docker pull ghcr.io/ssec-jhu/base-template:pr-1``.
+  * The site can then be accessed using any browser from ``http://localhost``
 
-  #### with Python ecosystem:
+  #### with Python ecosystem (for development):
   * Follow the above [Build with Python ecosystem instructions](#with-python-ecosystem).
-  * Run ``uvicorn biospecdb.asgi:application --host 0.0.0.0 --port 8000``. _NOTE: This is just an example and is obviously application dependent._
+  * For a completely fresh start and rebuild of the database: ``./scripts/dev/rebuild_db.sh``.
+  * Run ``DJANGO_SETTINGS_MODULE=biospecdb.settings.dev python manage.py runserver 0.0.0.0:8000``
+  * The site can then be accessed using any browser from ``http://localhost:8000``
 
 
 ### Custom Deployment Settings:
@@ -124,7 +130,7 @@ population of the ``QCAnnotation`` table is configurable and is described below.
 
 #### Settings:
 
-The following QC annotator settings are available in ``biospecdb.settings``:
+The following QC annotator settings are available in ``biospecdb.settings.base``:
 
  * ``AUTO_ANNOTATE``: If ``True`` and if default annotators exist in the DB, they will be automatically run upon
                       adding/updating ``SpectralData`` entries. _(Default: True)_

--- a/biospecdb/settings/base.py
+++ b/biospecdb/settings/base.py
@@ -15,25 +15,15 @@ import os
 import sys
 
 
-PROJECT_ROOT = os.path.dirname(__file__)
+PROJECT_ROOT = Path(os.path.dirname(__file__)).parent
 sys.path.insert(0, os.path.join(PROJECT_ROOT, 'apps'))
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent
-
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
-
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-9ppt7g3y2ds5+nig07x(#8^th-olh5u=kr_tiqs$2*h(u!y&^m'
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-ALLOWED_HOSTS = ['*']
-
 
 # Application definition
 
@@ -137,7 +127,9 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.1/howto/static-files/
 
-STATIC_URL = 'static/'
+STATIC_ROOT = BASE_DIR / "static/"
+STATIC_URL = '/static/'
+STATICFILES_DIRS = [os.path.join(BASE_DIR, 'biospecdb/apps/uploader/templates/static')]
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
@@ -191,9 +183,6 @@ EXPLORER_DATA_EXPORTERS = [
     ('excel', 'uploader.exporters.ExcelExporter'),
     ('json', 'uploader.exporters.JSONExporter')
 ]
-
-STATIC_URL = '/static/'
-STATICFILES_DIRS = [os.path.join(BASE_DIR, 'biospecdb/apps/uploader/templates/static')]
 
 EXPLORER_SCHEMA_INCLUDE_VIEWS = True
 

--- a/biospecdb/settings/base.py
+++ b/biospecdb/settings/base.py
@@ -11,16 +11,15 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 
 from pathlib import Path
-import os
 import sys
 
-
-PROJECT_ROOT = Path(os.path.dirname(__file__)).parent
-sys.path.insert(0, os.path.join(PROJECT_ROOT, 'apps'))
-
+from biospecdb import __project__
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
+PROJECT_ROOT = BASE_DIR / __project__
+APPS_DIR = PROJECT_ROOT / 'apps'
+sys.path.insert(0, str(APPS_DIR))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
@@ -128,8 +127,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.1/howto/static-files/
 
 STATIC_ROOT = BASE_DIR / "static/"
-STATIC_URL = '/static/'
-STATICFILES_DIRS = [os.path.join(BASE_DIR, 'biospecdb/apps/uploader/templates/static')]
+STATICFILES_DIRS = [APPS_DIR / "uploader/templates/static"]
+STATIC_URL = "/static/"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field

--- a/biospecdb/settings/dev.py
+++ b/biospecdb/settings/dev.py
@@ -1,0 +1,9 @@
+from .base import *  # noqa F403
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = 'django-insecure-9ppt7g3y2ds5+nig07x(#8^th-olh5u=kr_tiqs$2*h(u!y&^m'
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+ALLOWED_HOSTS = ['*']

--- a/biospecdb/settings/prd.py
+++ b/biospecdb/settings/prd.py
@@ -1,0 +1,23 @@
+import os
+
+from .base import *  # noqa F403
+
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
+# e.g., python manage.py check --deploy --settings=biospecdb.settings.prd
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = os.environ["SECRET_KEY"]
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = False
+
+# SESSION_COOKIE_SECURE = True
+# CSRF_COOKIE_SECURE = True
+# SECURE_HSTS_SECONDS = 2592000  # (30 days). See https://securityheaders.com/
+# SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+# SECURE_HSTS_PRELOAD = True
+# SECURE_SSL_REDIRECT = True
+
+ALLOWED_HOSTS = ['.localhost']  # TODO: replace with domain name

--- a/codecov.yml
+++ b/codecov.yml
@@ -22,3 +22,4 @@ ignore:
   - "biospecdb/apps/dash"
   - "biospecdb/asgi.py"
   - "biospecdb/wsgi.py"
+  - "biospecdb/settings"

--- a/config/gunicorn/dev.py
+++ b/config/gunicorn/dev.py
@@ -1,0 +1,29 @@
+"""Gunicorn *development* config file"""
+
+# Django WSGI application path in pattern MODULE_NAME:VARIABLE_NAME
+wsgi_app = "biospecdb.wsgi:application"
+
+# The socket to bind
+bind = "0.0.0.0:8000"
+
+# The granularity of Error log outputs
+loglevel = "debug"
+
+# The number of worker processes for handling requests
+workers = 1
+worker_class = "sync"
+
+# Restart workers when code changes (development only!)
+reload = True
+
+# Write access and error info to:
+accesslog = errorlog = "log/dev.log"
+
+# Redirect stdout/stderr to log file
+capture_output = True
+
+# PID file so you can easily fetch process ID
+pidfile = "run/dev.pid"
+
+# Daemonize the Gunicorn process (detach & enter background)
+daemon = False

--- a/config/gunicorn/prd.py
+++ b/config/gunicorn/prd.py
@@ -13,7 +13,6 @@ loglevel = "info"
 
 # The number of worker processes for handling requests.
 # Note: this is multiprocessing and not multithreading, because the GIL.
-# Note: Keep in mind that sqlite blocks on all connections and has no concurrency!
 workers = multiprocessing.cpu_count() * 2 + 1
 worker_class = "sync"
 threads = 1  # Run each worker with this specified number of threads.

--- a/config/gunicorn/prd.py
+++ b/config/gunicorn/prd.py
@@ -1,0 +1,47 @@
+"""Gunicorn *production* config file"""
+import multiprocessing
+
+
+# Django WSGI application path in pattern MODULE_NAME:VARIABLE_NAME
+wsgi_app = "biospecdb.wsgi:application"
+
+# The socket to bind
+bind = "0.0.0.0:8000"
+
+# The granularity of Error log outputs
+loglevel = "info"
+
+# The number of worker processes for handling requests.
+# Note: this is multiprocessing and not multithreading, because the GIL.
+# Note: Keep in mind that sqlite blocks on all connections and has no concurrency!
+workers = multiprocessing.cpu_count() * 2 + 1
+worker_class = "sync"
+threads = 1  # Run each worker with this specified number of threads.
+# Note: If you try to use the sync worker type and set the threads setting to more than 1, the gthread worker class will
+# be used instead.
+assert threads == 1
+
+# Restart workers when code changes (development only!)
+reload = False
+
+# The maximum number of requests a worker will process before restarting (mitigates memory leaks).
+max_requests = 10000
+max_requests_jitter = int(max_requests * 0.01)  # 1% of max_requests.
+
+# Workers silent for more than this many seconds are killed and restarted.
+timeout = 60
+# After receiving a restart signal, workers have this much time to finish serving requests.
+graceful_timeout = 30
+
+# Write access and error info to:
+accesslog = "log/prd_access.log"
+errorlog = "log/prd_error.log"
+
+# Redirect stdout/stderr to log file
+capture_output = True
+
+# PID file so you can easily fetch process ID
+pidfile = "run/prd.pid"
+
+# Daemonize the Gunicorn process (detach & enter background)
+daemon = False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,11 @@ version: '3.8'
 
 services:
   db-setup:
-    image: bsr
+    image: biospecdb
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: bsr-db-initializer
+    container_name: biospecdb-db-initializer
     restart: "no"
     volumes:
       - db-data:/app/db
@@ -14,11 +14,14 @@ services:
       - bulk-upload-files:/app/raw_data
       - spectaldata-files:/app/datasets
     environment:
-      DJANGO_SETTINGS_MODULE: biospecdb.settings
+      DJANGO_SETTINGS_MODULE: biospecdb.settings.prd
     secrets:
       - superuser_password
+      - django_secret_key
     command: >
-      bash -c "[ ! -f /app/db/setup_complete.txt ]
+      bash -c "set -e
+      [ ! -f /app/db/setup_complete.txt ]
+      && export SECRET_KEY=$(cat /run/secrets/django_secret_key)
       && python manage.py makemigrations user
       && python manage.py makemigrations uploader
       && python manage.py makemigrations catalog
@@ -34,25 +37,61 @@ services:
     depends_on:
       db-setup:
         condition: service_completed_successfully
-    image: bsr
-    restart: unless-stopped
-    ports:
-      - "8000:8000"
+    image: biospecdb
+    deploy:
+      mode: global
+      restart_policy:
+       condition: on-failure
+       delay: 5s
+       max_attempts: 3
+       window: 60s
+    expose:
+      - 8000
     volumes:
       - db-data:/app/db
       - spectaldata-files:/app/spectral_data
       - bulk-upload-files:/app/raw_data
-      - spectaldata-files:/app/datasets
+      - dataset-catalog-files:/app/datasets
+      - static_files:/app/static
     environment:
-      DJANGO_SETTINGS_MODULE: biospecdb.settings
-    command: python manage.py runserver 0.0.0.0:8000
+      DJANGO_SETTINGS_MODULE: biospecdb.settings.prd
+    secrets:
+      - django_secret_key
+    command: >
+      bash -c "mkdir -p log
+      && mkdir -p run
+      && SECRET_KEY=$(cat /run/secrets/django_secret_key) python manage.py collectstatic --clear --noinput
+      && SECRET_KEY=$(cat /run/secrets/django_secret_key) gunicorn -c config/gunicorn/prd.py"
+
+  nginx:
+    build: ./nginx
+    deploy:
+      mode: global
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 10s
+    container_name: biospecdb-nginx
+    ports:
+      - "80:80"
+    volumes:
+      - static_files:/static
+      - spectaldata-files:/spectral_data
+      - bulk-upload-files:/raw_data
+      - dataset-catalog-files:/datasets
+    depends_on:
+      - web
 
 secrets:
   superuser_password:
     environment: DJANGO_SUPERUSER_PASSWORD
+  django_secret_key:
+    environment: SECRET_KEY
 
 volumes:
   db-data:
   spectaldata-files:
   bulk-upload-files:
   dataset-catalog-files:
+  static_files:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,7 @@ autosummary_generate = True
 sys.path.insert(0, os.path.abspath(".."))  # For discovery of Python modules
 
 # This tells Django where to find the settings file
-os.environ["DJANGO_SETTINGS_MODULE"] = "biospecdb.settings"
+os.environ["DJANGO_SETTINGS_MODULE"] = "biospecdb.settings.dev"
 # This activates Django and makes it possible for Sphinx to
 # autodoc your project
 django.setup()

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:latest
+
+RUN rm /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d/

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,36 @@
+upstream  biospecdb {
+    server web:8000;
+}
+
+server_tokens   off;
+error_log   /var/log/nginx/biospecdb.error.log;
+access_log  /var/log/nginx/biospecdb.access.log;
+
+server {
+    listen       80;
+    server_name  localhost; # TODO: Update with domain name.
+
+    location / {
+        proxy_pass          http://biospecdb/;
+        proxy_set_header    Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_redirect off;
+        client_max_body_size 100M;
+    }
+
+    location /static/ {
+        alias /static/;
+    }
+
+    location /datasets/ {
+        alias /datasets/;
+    }
+
+    location /raw_data/ {
+        alias /raw_data/;
+    }
+
+    location /spectral_data/ {
+        alias /spectral_data/;
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,11 @@ dependencies = [
     "django-decorator-include",
     "django-nested-admin",
     "django-sql-explorer[charts]",
+    "gunicorn",
     "kaleido",
     "openpyxl",
     "pandas",
     "plotly",
-    "uvicorn",
     "xlsxwriter"
 ]
 
@@ -61,7 +61,7 @@ include-package-data = true
 write_to = "biospecdb/_version.py"
 
 [tool.pytest.ini_options]
-DJANGO_SETTINGS_MODULE = "biospecdb.settings"
+DJANGO_SETTINGS_MODULE = "biospecdb.settings.dev"
 markers = [
     "allow_aliases: override setiings.EXPLORER_DATA_EXPORTERS_ALLOW_DATA_FILE_ALIAS (where applicable)",
     "media_root: override settings.MEDIA_ROOT (where applicable)",

--- a/requirements/prd.txt
+++ b/requirements/prd.txt
@@ -2,9 +2,9 @@ django==4.2.7
 django-decorator-include==3.0
 django-nested-admin==4.0.2
 django-sql-explorer[charts]==3.2.1
+gunicorn==21.2.0
 kaleido==0.2.1
 openpyxl==3.1.2
 pandas==2.1.3
 plotly==5.18.0
-uvicorn[standard]==0.23.2
 xlsxwriter==3.1.9

--- a/scripts/dev/rebuild_db.sh
+++ b/scripts/dev/rebuild_db.sh
@@ -16,6 +16,12 @@ rm *.sqlite3
 
 set -e
 
+export DJANGO_SETTINGS_MODULE=biospecdb.settings.dev
+
+# Collect all static files to be served.
+# NOTE: `manage.py runserver` does this automatically, however, serving from gunicorn obviously doesn't.
+python manage.py collectstatic --clear --noinput
+
 # Redo migrations since they were deleted above.
 python manage.py makemigrations user
 python manage.py makemigrations uploader

--- a/scripts/prd/gen_secret_key.sh
+++ b/scripts/prd/gen_secret_key.sh
@@ -1,0 +1,1 @@
+export SECRET_KEY=$(openssl rand -hex 40)


### PR DESCRIPTION
## Deployment expectations:
This is not necessarily _the_ final deployment, we're waiting for definition of which cloud service provider the PI would like to use. Even then, we'll probably only whip up a working example/foundation for them. With that in mind, the docker-compose script is similar in that context, however, we can now at least provide _a_ mechanism for standing up a prd service if need be.

## Changes:
* Use ``gunicorn`` in prd deployment.
* Use ``nginx`` in front of gunicorn for all traffic.
* Serve static files (e.g., .css) and media files (e.g., downloading data files) from ``nginx``.
* Configure ``docker-compose`` for prd deployment.

## TODO?:
* Build & deploy using ``docker-compose`` as part of github CI?
* what to do about github package for docker image?

## Punt:
* Need domain name for:
  * ``biospecdb.settings.prd.ALLOWED_HOSTS``
  * ``nginx/nginx.conf:server_name``
* See #211 for SSL/https: we need certificates. Changes needed for:
  * ``config/gunicorn/prd.py``
  * ``nginx/nginx.conf``
  * ``biospecdb/settings/prd.py``