### PR TITLE
SSL support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ datasets/
 log/
 run/
 static/
+nginx/cert.*

--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ For additional cmds see the [Conda cheat-sheet](https://docs.conda.io/projects/c
   * Setup env vars:
     * ``export DJANGO_SUPERUSER_PASSWORD=admin``
     * ``source scripts/prd/gen_secret_key.sh``
+  * Copy both the SSL certificate and the private key to ``nginx/cert.crt`` & ``nginx/cert.key`` respectively. For local
+    testing of the prd service see [creating self-signed SSL certificates](#self-signed-ssl-certificates) for
+    instructions on how to create "fake" ones.
   * Build and run with ``docker compose up``, add ``-d`` to run in the background.
-  * Alternatively, images can be pulled from ``ghcr.io/ssec-jhu/`` e.g., ``docker pull ghcr.io/ssec-jhu/base-template:pr-1``.
-  * The site can then be accessed using any browser from ``http://localhost``
+  * The site can then be accessed using any browser from ``https://localhost``
 
   #### with Python ecosystem (for development):
   * Follow the above [Build with Python ecosystem instructions](#with-python-ecosystem).
@@ -57,6 +59,15 @@ For additional cmds see the [Conda cheat-sheet](https://docs.conda.io/projects/c
   * Run ``DJANGO_SETTINGS_MODULE=biospecdb.settings.dev python manage.py runserver 0.0.0.0:8000``
   * The site can then be accessed using any browser from ``http://localhost:8000``
 
+  ### Self signed SSL certificates:
+    Warning! This is intended of local testing only and not for use in production.
+  * Install ``openssl``
+  * ``cd nginx``
+  * Create private key: ``openssl genrsa -out cert.key 4096``
+  * Create the certificate singing request (CSR): ``openssl req -new -key cert.key -out cert.csr``
+  * Create and sign the certificate with the private key: ``openssl x509 -req -days 365 -in cert.csr -signkey cert.key -out cert.crt``
+    Note: This certificate is valid for 365 days. Also, when accessing https://localhost your browser will flag the site
+    as unsafe and the certificate as invalid. 
 
 ### Custom Deployment Settings:
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,7 @@ For additional cmds see the [Conda cheat-sheet](https://docs.conda.io/projects/c
     Warning! This is intended of local testing only and not for use in production.
   * Install ``openssl``
   * ``cd nginx``
-  * Create private key: ``openssl genrsa -out cert.key 4096``
-  * Create the certificate singing request (CSR): ``openssl req -new -key cert.key -out cert.csr``
-  * Create and sign the certificate with the private key: ``openssl x509 -req -days 365 -in cert.csr -signkey cert.key -out cert.crt``
+  * ``openssl req -newkey rsa:4096 -nodes -x509 -out cert.crt -keyout cert.key -days 365``
     Note: This certificate is valid for 365 days. Also, when accessing https://localhost your browser will flag the site
     as unsafe and the certificate as invalid. 
 

--- a/biospecdb/settings/prd.py
+++ b/biospecdb/settings/prd.py
@@ -13,11 +13,13 @@ SECRET_KEY = os.environ["SECRET_KEY"]
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
-# SESSION_COOKIE_SECURE = True
-# CSRF_COOKIE_SECURE = True
-# SECURE_HSTS_SECONDS = 2592000  # (30 days). See https://securityheaders.com/
-# SECURE_HSTS_INCLUDE_SUBDOMAINS = True
-# SECURE_HSTS_PRELOAD = True
-# SECURE_SSL_REDIRECT = True
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+SECURE_HSTS_SECONDS = 2592000  # (30 days). See https://securityheaders.com/
+SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+SECURE_HSTS_PRELOAD = True
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
+SECURE_SSL_REDIRECT = True
 
 ALLOWED_HOSTS = ['.localhost']  # TODO: replace with domain name

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
     container_name: biospecdb-nginx
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - static_files:/static
       - spectaldata-files:/spectral_data

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -2,3 +2,6 @@ FROM nginx:latest
 
 RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx.conf /etc/nginx/conf.d/
+
+COPY cert.crt /biospecdb.crt
+COPY cert.key /biospecdb.key

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -2,20 +2,38 @@ upstream  biospecdb {
     server web:8000;
 }
 
+# Disable emitting nginx version in the "Server" response header field
 server_tokens   off;
+
 error_log   /var/log/nginx/biospecdb.error.log;
 access_log  /var/log/nginx/biospecdb.access.log;
 
+# Return 444 status code & close connection if no Host header present
 server {
-    listen       80;
-    server_name  localhost; # TODO: Update with domain name.
+  listen                  80 default_server;
+  return                  444;
+}
+
+# Redirect HTTP to HTTPS
+server {
+  server_name             localhost;  # TODO: Update with domain name.
+  listen                  80;
+  return                  307 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name  localhost;  # TODO: Update with domain name.
+    ssl_certificate /biospecdb.crt;
+    ssl_certificate_key /biospecdb.key;
 
     location / {
-        proxy_pass          http://biospecdb/;
-        proxy_set_header    Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_redirect off;
-        client_max_body_size 100M;
+        proxy_pass              http://biospecdb/;
+        proxy_set_header        Host $host;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_redirect          off;
+        client_max_body_size    100M;
     }
 
     location /static/ {


### PR DESCRIPTION
Add SSL support.

Note that using docker-compose locally now requires spoofed ssl certs for it to work, and even then you'll have to work around this in the browser by accepting the fake certificate etc.