### PR TITLE
Improvements to Visit.previous_visit

### DIFF
--- a/biospecdb/apps/uploader/loaddata.py
+++ b/biospecdb/apps/uploader/loaddata.py
@@ -72,7 +72,6 @@ def save_data_to_db(meta_data, spectral_data, center=None, joined_data=None, dry
                         patient.save()
 
                 # Visit
-                # TODO: Add logic to auto-find previous_visit. https://github.com/ssec-jhu/biospecdb/issues/37
                 visit = Visit(patient=patient, **Visit.parse_fields_from_pandas_series(row))
                 visit.full_clean()
                 visit.save()

--- a/biospecdb/apps/uploader/models.py
+++ b/biospecdb/apps/uploader/models.py
@@ -228,7 +228,8 @@ class Visit(DatedModel):
             raise ValidationError(_("Previous visits do not belong to this patient!"), code="invalid")
 
         # Validate visits are entered ordered by age.
-        if self.previous_visit is not None and (self.patient_age < self.previous_visit.patient_age):
+        if settings.AUTO_FIND_PREVIOUS_VISIT and (self.previous_visit is not None) and \
+                (self.patient_age < self.previous_visit.patient_age):
             raise ValidationError(_("Previous visit must NOT be older than this one: patient age before %(prior_age)i "
                                     " > %(current_age)i"),
                                   params={"current_age": self.patient_age,
@@ -281,7 +282,7 @@ class Visit(DatedModel):
         return self.patient.center
 
     def __str__(self):
-        return f"patient:{self.patient.short_id()}_visit:{self.visit_number}"
+        return f"patient:{self.patient}_visit:{self.visit_number}"
 
 
 class Observable(ModelWithViewDependency):

--- a/biospecdb/apps/uploader/tests/test_models.py
+++ b/biospecdb/apps/uploader/tests/test_models.py
@@ -170,6 +170,7 @@ class TestVisit:
         visit.full_clean()
         assert visit.previous_visit == Visit.objects.get(pk=2)
 
+    @pytest.mark.auto_find_previous_visit(True)
     def test_previous_visit_patient_age_validation(self, db, visits):
         previous_visit = Visit.objects.get(pk=1)
         visit = Visit(patient=previous_visit.patient,

--- a/biospecdb/settings/base.py
+++ b/biospecdb/settings/base.py
@@ -211,8 +211,8 @@ RUN_DEFAULT_ANNOTATORS_WHEN_SAVED = False
 DISABLE_QC_MANAGER = True
 
 # Auto-populate the model field ``Visit.previous_visit`` by searching for existing older visits and choosing the last.
-# WARNING! This may give incorrect results.
-AUTO_FIND_PREVIOUS_VISIT = True
+# WARNING! This may give incorrect results, e.g., when retrospectively adding prior visits.
+AUTO_FIND_PREVIOUS_VISIT = False
 
 # Data Catalog settings:
 


### PR DESCRIPTION
Replacement for #212

Previous visit hasn't been removed from the model or the forms, it has been slightly hidden from the forms as a collapsable formset.

Collapsed (default):
<img width="950" alt="Screenshot 2024-01-25 at 2 51 09 PM" src="https://github.com/ssec-jhu/biospecdb/assets/5013975/c296c24c-985b-45b8-8e69-dc93be204981">

expanded:
<img width="947" alt="Screenshot 2024-01-25 at 2 51 18 PM" src="https://github.com/ssec-jhu/biospecdb/assets/5013975/a6fb24e7-d946-4318-a238-2ac7818c4abe">

``settings.AUTO_FIND_PREVIOUS_VISIT`` has been turned off as the default functionality. Sequential age validation has been added when this flag is ``True`` to prevent incorrect results when visits are retrospectively added, i.e., out of order in real-time - can't add a visit with age less than the last visit. Though, [Make patient_age an observable](https://www.notion.so/Make-patient_age-an-observable-67b934b46bad4bbaaa89fd848bd18bfd?pvs=4) may perhaps destroy this functionality entirely.