### PR TITLE
Add prune_files management command to delete orphaned files

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ For additional cmds see the [Conda cheat-sheet](https://docs.conda.io/projects/c
     data samples in the database. See [Quality Control Annotations](#quality-control-annotations).
 
 
-### DB Management:
+# DB Management
 We're currently using sqlite requiring the following setup instructions:
 
 For a quickstart run the provided script [rebuild_db.sh](scripts/dev/rebuild_db.sh), otherwise follow the instructions
@@ -120,11 +120,20 @@ The DB can be dumped to a file using the following:
 
 `` python manage.py dumpdata --indent 4 uploader --exclude uploader.uploadedfile --output test_data.json``
 
-### Usage:
+### Custom commands:
+
+ * ``python manage.py prune_files [--dry_run]``: Delete any and all orphaned data files.
+   * ``--dry_run``: Output files to be deleted but don't actually delete anything.
+ * ``python manage.py update_sql_views``: Create/update all custom SQL views in uploader.models.
+ * ``python manage.py run_qc_annotators [--no_reruns]``: Run all Quality Control annotators on the SpectralData database table.
+   * ``--no_reruns``: Don't run annotators on existing annotations, leave computed values as is.
+
+
+# Usage
 
     WIP.
 
-## Quality Control Annotations.
+# Quality Control Annotations
 
 Entries in the ``SpectralData`` table can be annotated by running ``QCAnnotators`` on them, thus producing a value
 stored as an ``ACAnnotation`` associated with the ``SpectralData`` entry. The ``SpectralData`` table contains the actual

--- a/biospecdb/apps/uploader/management/commands/prune_files.py
+++ b/biospecdb/apps/uploader/management/commands/prune_files.py
@@ -1,0 +1,50 @@
+import os
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+
+from uploader.models import SpectralData, UploadedFile
+
+
+class Command(BaseCommand):
+    help = "Delete any and all orphaned data files."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry_run",
+                            action="store_true",
+                            default=False,
+                            help="Output files to be deleted but don't actually delete anything.")
+
+    def handle(self, *args, **options):
+        try:
+            # Collect orphaned bulk data files.
+            fs_files = set(Path(UploadedFile.UPLOAD_DIR).glob("*"))
+            meta_data_files = set(x.meta_data_file.name for x in UploadedFile.objects.all())
+            spectral_data_files = set(x.spectral_data_file.name for x in UploadedFile.objects.all())
+            orphaned_files = fs_files - (meta_data_files | spectral_data_files)
+
+            # Collect orphaned spectral data files.
+            fs_files = set(Path(SpectralData.UPLOAD_DIR).glob("*"))
+            data_files = set(x.data.name for x in SpectralData.objects.all())
+            orphaned_files |= fs_files - data_files
+
+            if not orphaned_files:
+                self.stdout.write(self.style.WARNING("No orphaned files detected."))
+                return
+
+            # Delete orphaned files.
+            for i, file in enumerate(orphaned_files):
+                msg = f"{i + 1}/{len(orphaned_files)} files: '{file}'..."
+                if options["dry_run"]:
+                    self.stdout.write(msg)
+                else:
+                    self.stdout.write(f"Deleting {msg}")
+                    os.remove(file)
+
+            if options["dry_run"]:
+                self.stdout.write(self.style.SUCCESS("[Done] 0 files deleted"))
+            else:
+                self.stdout.write(self.style.SUCCESS(f"[Done] {len(orphaned_files)} files deleted"))
+
+        except Exception as error:
+            raise CommandError(f"An error occurred whilst trying to delete orphaned data files: - '{error}'")

--- a/biospecdb/apps/uploader/management/commands/prune_files.py
+++ b/biospecdb/apps/uploader/management/commands/prune_files.py
@@ -36,13 +36,16 @@ class Command(BaseCommand):
             for i, file in enumerate(orphaned_files):
                 msg = f"{i + 1}/{len(orphaned_files)} files: '{file}'..."
                 if options["dry_run"]:
-                    self.stdout.write(msg)
+                    self.stdout.write("(dry-run) " + msg)
                 else:
                     self.stdout.write(f"Deleting {msg}")
-                    os.remove(file)
+                    try:
+                        os.remove(file)
+                    except FileNotFoundError:
+                        continue
 
             if options["dry_run"]:
-                self.stdout.write(self.style.SUCCESS("[Done] 0 files deleted"))
+                self.stdout.write(self.style.SUCCESS("(dry-run) [Done] 0 files deleted"))
             else:
                 self.stdout.write(self.style.SUCCESS(f"[Done] {len(orphaned_files)} files deleted"))
 

--- a/biospecdb/apps/uploader/tests/conftest.py
+++ b/biospecdb/apps/uploader/tests/conftest.py
@@ -46,16 +46,15 @@ class UserFactory(ExplorerUserFactory):
 def rm_dir(path):
     if path.exists() and path.is_dir():
         shutil.rmtree(path)
+        assert not path.exists()
 
 
 def rm_all_media_dirs():
     from catalog.models import Dataset
     # Tidy up any created files.
-    media_root = Path(settings.MEDIA_ROOT)
-    rm_dir(media_root / UploadedFile.meta_data_file.field.upload_to)
-    rm_dir(media_root / UploadedFile.spectral_data_file.field.upload_to)
-    rm_dir(media_root / SpectralData.data.field.upload_to)
-    rm_dir(media_root / Dataset.file.field.upload_to)
+    rm_dir(Path(UploadedFile.UPLOAD_DIR))
+    rm_dir(Path(SpectralData.UPLOAD_DIR))
+    rm_dir(Path(Dataset.UPLOAD_DIR))
 
 
 class SimpleQueryFactory(DjangoModelFactory):

--- a/biospecdb/apps/uploader/tests/test_management_commands.py
+++ b/biospecdb/apps/uploader/tests/test_management_commands.py
@@ -1,0 +1,33 @@
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from django.core.management import call_command
+
+from uploader.models import UploadedFile, SpectralData
+
+
+@pytest.mark.django_db(databases=["default", "bsr"])
+class TestPruneFiles:
+
+    def test_empty(self):
+        out = StringIO()
+        call_command("prune_files", stdout=out)
+        assert "No orphaned files detected." in out.getvalue()
+
+    @pytest.mark.parametrize(("cmd", "expected"),
+                             ((("prune_files",), (0, 0)),
+                              (("prune_files", "--dry_run"), (2, 10))))
+    def test_core(self, mock_data_from_files, cmd, expected):
+        assert len(list(Path(UploadedFile.UPLOAD_DIR).glob('*'))) == 2
+        assert len(list(Path(SpectralData.UPLOAD_DIR).glob('*'))) == 10
+
+        out = StringIO()
+        call_command(*cmd, stdout=out)
+
+        assert len(list(Path(UploadedFile.UPLOAD_DIR).glob('*'))) == expected[0]
+        assert len(list(Path(SpectralData.UPLOAD_DIR).glob('*'))) == expected[1]
+
+        out.seek(0)
+        assert len(out.readlines()) == 13


### PR DESCRIPTION
Resolves [Notion ticket](https://www.notion.so/Django-doesn-t-delete-files-on-disk-when-dereferenced-from-the-DB-e12623af4c8d471db8a39b6dceb3cfdb?pvs=4)
Resolves #39 

## TODO:
- [x] Add tests
- [ ] Add cronjob to docker? PUNT - perhaps even indefinitely as it may be better to manually do this.