### PR TITLE
Fix formfield_for_foreignkey inheritance call order clobbering

### DIFF
--- a/biospecdb/apps/uploader/models.py
+++ b/biospecdb/apps/uploader/models.py
@@ -237,7 +237,10 @@ class Visit(DatedModel):
         if self.previous_visit is not None:
             try:
                 patient_age = int(self.observation.get(observable__name="patient_age").observable_value)
-            except Observation.DoesNotExist:
+            except (Observation.DoesNotExist, ValueError):
+                # Note: ``ValueError`` accounts for ``self.observation`` when self.pk hasn't yet been set, since objs
+                # are cleaned before saving and the DB populates the pk. Relationships and their traversal aren't
+                # possible for objs without primary keys.
                 pass
             else:
                 try:


### PR DESCRIPTION
Changes:
 * Model admin ``formfield_for_foreignkey`` methods were clobbering their supers instead of filtering on them. This PR fixes that.
 * Tighten object visibility to the user's center across all fields.
