### PR TITLE
Collapsable inline observations

### DIFF
--- a/biospecdb/apps/uploader/admin.py
+++ b/biospecdb/apps/uploader/admin.py
@@ -333,7 +333,8 @@ class ObservationInline(ObservationMixin, RestrictedByCenterMixin, NestedTabular
     @classmethod
     def factory(cls):
         return [type(f"{x}ObservationInline", (cls,), dict(verbose_name=x.lower(),
-                                                           verbose_name_plural=x.lower())) for x in Observable.Category]
+                                                           verbose_name_plural=x.lower(),
+                                                           classes=("collapse",))) for x in Observable.Category]
 
 
 @admin.register(Observation)


### PR DESCRIPTION
Resolves [Notion ticket](https://www.notion.so/Make-inline-observation-fieldsets-collapsable-e4c5436114584f67839247aa43b84411?pvs=4)

They will be collapsed by default.

<img width="1250" alt="Screenshot 2024-02-08 at 10 51 18 AM" src="https://github.com/ssec-jhu/biospecdb/assets/5013975/0b6fbf49-48f3-4ee6-a194-0f2fd480fc4d">

See [Django docs](https://docs.djangoproject.com/en/5.0/ref/contrib/admin/#django.contrib.admin.InlineModelAdmin.classes)