### PR TITLE
Exclude user, catalog, & uploader_center from sql explorer schema

### DIFF
--- a/biospecdb/settings/base.py
+++ b/biospecdb/settings/base.py
@@ -174,7 +174,11 @@ EXPLORER_SCHEMA_EXCLUDE_TABLE_PREFIXES = (
     'sessions',
     'admin',
     "django",
-    "explorer"
+    "explorer",
+    "user",
+    "catalog",
+    "uploader_center"
+
 )
 
 EXPLORER_DATA_EXPORTERS = [


### PR DESCRIPTION
Resolves [Notion ticket](https://www.notion.so/Table-exclusion-list-for-sql-explorer-78543890f5f241479d876c2091d540ef?pvs=4)

Note: these are excluded only from appearing in the schema, they are still totally accessible - as is everything.