### PR TITLE
Add health checks

### DIFF
--- a/biospecdb/settings/base.py
+++ b/biospecdb/settings/base.py
@@ -38,6 +38,11 @@ INSTALLED_APPS = [
     "uploader.apps.UploaderConfig",
     "user.apps.UserConfig",
     "catalog.apps.CatalogConfig",
+    "health_check",
+    "health_check.db",
+    "health_check.cache",
+    "health_check.storage",
+    "health_check.contrib.migrations"
 ]
 
 MIDDLEWARE = [

--- a/biospecdb/urls.py
+++ b/biospecdb/urls.py
@@ -30,6 +30,7 @@ from catalog.admin import catalog_admin
 admin.site.site_header = "Biosample Spectral Repository administration"
 
 urlpatterns = [
+    path(r"healthz/", include("health_check.urls")),
     path("favicon.ico", views.favicon),
     path('', RedirectView.as_view(pattern_name="home", permanent=True)),
     path('uploader/', include('biospecdb.apps.uploader.urls')),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.11"
 dependencies = [
     "django",
     "django-decorator-include",
+    "django-health-check",
     "django-nested-admin",
     "django-sql-explorer[charts]",
     "gunicorn",

--- a/requirements/prd.txt
+++ b/requirements/prd.txt
@@ -1,5 +1,6 @@
 django==4.2.7
 django-decorator-include==3.0
+django-health-check==3.18.1
 django-nested-admin==4.0.2
 django-sql-explorer[charts]==3.2.1
 gunicorn==21.2.0

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,0 +1,32 @@
+import json
+import pytest
+
+from django.test import Client
+
+
+@pytest.mark.django_db(databases=["default", "bsr"])
+class TestHealthCheck:
+    def test_healthz(self):
+        c = Client()
+        response = c.get("/healthz/")
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize(("url", "header"), (("/healthz/?format=json", None),
+                                                 ("/healthz/", {"accept": "application/json"})))
+    def test_healthz_json(self, url, header):
+        c = Client()
+        response = c.get(url, headers=header)
+
+        assert response.status_code == 200
+
+        content = json.loads(response.content)
+
+        # There should be an entry for each of the installed checks:
+        assert len(content) == 4
+        assert "Cache backend: default" in content
+        assert "DatabaseBackend" in content
+        assert "DefaultFileStorageHealthCheck" in content
+        assert "MigrationsHealthCheck" in content
+
+        for x in content.values():
+            assert x.strip().lower() == "working"


### PR DESCRIPTION
Resolves [Notion ticket](https://www.notion.so/Add-healthz-9a01d55f7fce4bce8b230ba2e43e32c9?pvs=4)

Use https://github.com/revsys/django-health-check to create a ``healthz/`` health check.

TODOs:

- [ ] ~Incorporate into docker health check.~ Punt to #248 as I'm not sure how to implement this.

<img width="1025" alt="Screenshot 2024-02-13 at 8 03 11 PM" src="https://github.com/ssec-jhu/biospecdb/assets/5013975/288c2c51-2f12-4772-8c9f-6039abe229a6">
