### PR TITLE
Don't run Model.clean() when field errors already exist

### DIFF
--- a/biospecdb/apps/uploader/admin.py
+++ b/biospecdb/apps/uploader/admin.py
@@ -12,6 +12,7 @@ from nested_admin import NestedStackedInline, NestedTabularInline, NestedModelAd
 from biospecdb.util import to_bool
 from .models import BioSample, Observable, Instrument, Patient, SpectralData, Observation, UploadedFile, Visit,\
     QCAnnotator, QCAnnotation, Center, get_center, BioSampleType, SpectraMeasurementType
+from uploader.forms import ModelForm
 
 User = get_user_model()
 
@@ -167,7 +168,7 @@ class InstrumentAdmin(RestrictedByCenterMixin, admin.ModelAdmin):
     ]
 
 
-class UploadedFileForm(forms.ModelForm):
+class UploadedFileForm(ModelForm):
     def add_error(self, field, error):
         """ Override this method for validation errors that aren't fields of this form.
 
@@ -323,7 +324,7 @@ class ObservationMixin:
         return qs.filter(visit__patient__center=Center.objects.get(pk=request.user.center.pk))
 
 
-class ObservationInlineForm(forms.ModelForm):
+class ObservationInlineForm(ModelForm):
     observables = iter([])
 
     @staticmethod

--- a/biospecdb/apps/uploader/forms.py
+++ b/biospecdb/apps/uploader/forms.py
@@ -1,0 +1,20 @@
+from django import forms
+
+
+class ModelForm(forms.ModelForm):
+    def _post_clean(self, *args, **kwargs):
+        """
+        An internal hook for performing additional cleaning after form cleaning
+        is complete. Used for model validation in model forms.
+
+        The clean order is as:
+        self._clean_fields()
+        self._clean_form()
+        self._post_clean() # <---- Model.clean() is called here.
+
+        If errors already exist, report these to user rather than dealing with model errors that may not make sense
+        when upstream field errors exist.
+        """
+        if self.errors:
+            return
+        return super()._post_clean(*args, **kwargs)


### PR DESCRIPTION
A model's clean method shouldn't have to handle upstream field errors. Instead, raise early.

TBH, I find the implementation of this super odd, to have to override ``ModelForm._post_clean()`` like this, however, I couldn't find anything concrete in the Django docs. They illude to, in multiple stmnts, the need to be aware of this but don't provide a framework soln. (that I could find).

[ModelForm](https://docs.djangoproject.com/en/5.0/ref/forms/validation/#form-and-field-validation)
> Also note that there are special considerations when overriding the clean() method of a ModelForm subclass. (see the [ModelForm documentation](https://docs.djangoproject.com/en/5.0/topics/forms/modelforms/#overriding-modelform-clean-method) for more information)

Without this, e.g., when adding a new bulk upload without specifying a center, ``uploader.loaddata.save_data_to_db()`` will raise an exception rather than the appropriate field validation error, that ``uploader.UploadedFile.center`` is a required field.

I guess this could be considered an extension of #245 