### PR TITLE
Double down on SQL explorer access perm settings

### DIFF
--- a/biospecdb/settings/base.py
+++ b/biospecdb/settings/base.py
@@ -146,6 +146,9 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 EXPLORER_CONNECTIONS = {"data": "bsr"}
 EXPLORER_DEFAULT_CONNECTION = "bsr"
 
+EXPLORER_PERMISSION_VIEW = lambda r: r.user.is_sqluser or r.user.is_superuser  # noqa:  E731
+EXPLORER_PERMISSION_CHANGE = lambda r: r.user.is_superuser  # noqa:  E731
+
 EXPLORER_DEFAULT_ROWS = 1000
 
 EXPLORER_SQL_BLACKLIST = (


### PR DESCRIPTION
This is effectively already handled in https://github.com/ssec-jhu/biospecdb/blob/main/biospecdb/urls.py#L39-L41, however, as per the [django-sql-explorer docs](https://django-sql-explorer.readthedocs.io/en/latest/settings.html#permission-view) we can double done and separate view perms from change/add perms.