### PR TITLE
Add password recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The DB can be dumped to a file using the following:
    * ``--exclude_non_observables``: Only output column names for non-observables.
    * ``--center=<name|id>``: Filter observables by center name or center ID.
    * ``--category=<category>``: Filter observables by category.
+ * ``python manage.py send_test_email <send_to_email_address>``: Send a test email to "send_to_email_address" to test email setup.
 
 _NOTE: These commands must be run from the ``/app/`` directory on the server.
 

--- a/biospecdb/apps/uploader/management/commands/send_test_email.py
+++ b/biospecdb/apps/uploader/management/commands/send_test_email.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+from django.core.mail import send_mail
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Test email server by sending a test email."
+
+    def add_arguments(self, parser):
+        parser.add_argument("email_address",
+                            default=None,
+                            help="Send test email to this email address.")
+
+    def handle(self, *args, **options):
+        email_address = options["email_address"]
+        email_from = settings.EMAIL_FROM
+        try:
+            send_mail("BiospecDB test email", "This is just a test.", email_from, [email_address],
+                      fail_silently=False)
+            self.stdout.write(self.style.SUCCESS(f"Test email sent to {email_address}"))
+        except CommandError:
+            raise
+        except Exception as error:
+            raise CommandError(f"An error occurred whilst trying to send a test email to '{email_address}': "
+                               f"{type(error).__name__}: {error}")

--- a/biospecdb/apps/uploader/tests/test_management_commands.py
+++ b/biospecdb/apps/uploader/tests/test_management_commands.py
@@ -41,7 +41,7 @@ class TestGetColumnNames:
     @pytest.fixture
     def more_observables(self, centers):
         category = (x.value for x in Observable.Category)
-        names = iter(("blah", "foo", "bar"))
+        names = iter(("blah", "foo", "bar", "huh"))
         for center in Center.objects.all():
             name = next(names)
             observable = Observable.objects.create(name=name,

--- a/biospecdb/apps/user/fixtures/centers.json
+++ b/biospecdb/apps/user/fixtures/centers.json
@@ -27,7 +27,7 @@
     "model": "user.Center",
     "pk": "16721944-ff91-4adf-8fb3-323b99aba801",
     "fields": {
-      "name": "spadd",
+      "name": "spadda",
       "country": "UK"
     }
   },
@@ -59,7 +59,7 @@
     "model": "uploader.Center",
     "pk": "16721944-ff91-4adf-8fb3-323b99aba801",
     "fields": {
-      "name": "spadd",
+      "name": "spadda",
       "country": "UK"
     }
   }

--- a/biospecdb/apps/user/fixtures/centers.json
+++ b/biospecdb/apps/user/fixtures/centers.json
@@ -23,6 +23,14 @@
       "country": "UK"
     }
   },
+    {
+    "model": "user.Center",
+    "pk": "16721944-ff91-4adf-8fb3-323b99aba801",
+    "fields": {
+      "name": "spadd",
+      "country": "UK"
+    }
+  },
   {
     "model": "uploader.Center",
     "pk": "d61f1c2a-9c0a-4309-a031-ab5b8d2106b0",
@@ -44,6 +52,14 @@
     "pk": "d2160c33-0bbc-4605-a2ce-7e83296e7c84",
     "fields": {
       "name": "Oxford University",
+      "country": "UK"
+    }
+  },
+  {
+    "model": "uploader.Center",
+    "pk": "16721944-ff91-4adf-8fb3-323b99aba801",
+    "fields": {
+      "name": "spadd",
       "country": "UK"
     }
   }

--- a/biospecdb/apps/user/tests/test_center.py
+++ b/biospecdb/apps/user/tests/test_center.py
@@ -49,8 +49,8 @@ class TestCenters:
         assert UploaderCenter.objects.count() == 0
 
     def test_delete_replication(self, centers):
-        assert UserCenter.objects.count() == 3
-        assert UploaderCenter.objects.count() == 3
+        assert UserCenter.objects.count() == 4
+        assert UploaderCenter.objects.count() == 4
 
         for obj in UserCenter.objects.all():
             obj.delete()
@@ -61,13 +61,13 @@ class TestCenters:
     def test_bulk_delete_replication(self, centers):
         """ Bulk delete doesn't call delete()!!! """
 
-        assert UserCenter.objects.count() == 3
-        assert UploaderCenter.objects.count() == 3
+        assert UserCenter.objects.count() == 4
+        assert UploaderCenter.objects.count() == 4
 
         UserCenter.objects.all().delete()
 
         assert not UserCenter.objects.all()
-        assert UploaderCenter.objects.count() == 3
+        assert UploaderCenter.objects.count() == 4
 
     def test_equivalence(self):
         user_center = UserCenter(name="test", country="nowhere")

--- a/biospecdb/settings/base.py
+++ b/biospecdb/settings/base.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 
+import os
 from pathlib import Path
 import sys
 
@@ -115,6 +116,19 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+
+LOGIN_URL = "/admin/login"
+LOGOUT_URL = "logout"
+
+# Email settings
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = "smtp.sendgrid.net"
+EMAIL_USE_TLS = True
+EMAIL_PORT = 587
+EMAIL_HOST_USER = "apikey"  # this is exactly the value 'apikey'
+EMAIL_HOST_PASSWORD = os.getenv("EMAIL_API_KEY", None)
+EMAIL_FROM = "admin@spadd.org"
+EMAIL_SUBJECT_PREFIX = "SPaDD"
 
 # Internationalization
 # https://docs.djangoproject.com/en/4.1/topics/i18n/

--- a/biospecdb/settings/base.py
+++ b/biospecdb/settings/base.py
@@ -116,7 +116,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-DOMAIN_NAME = "spadd.org"
+DOMAIN_NAME = "spadda.org"
 
 LOGIN_URL = "/admin/login"
 LOGOUT_URL = "logout"
@@ -126,10 +126,10 @@ EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = "smtp.sendgrid.net"
 EMAIL_USE_TLS = True
 EMAIL_PORT = 587
-EMAIL_HOST_USER = "apikey"  # this is exactly the value 'apikey'
+EMAIL_HOST_USER = "apikey"  # this is exactly the value 'apikey', this is NOT a placeholder.
 EMAIL_HOST_PASSWORD = os.getenv("EMAIL_API_KEY", None)
 EMAIL_FROM = f"admin@{DOMAIN_NAME}"
-EMAIL_SUBJECT_PREFIX = "SPaDD"
+EMAIL_SUBJECT_PREFIX = "SPaDDa"
 
 # Internationalization
 # https://docs.djangoproject.com/en/4.1/topics/i18n/

--- a/biospecdb/settings/base.py
+++ b/biospecdb/settings/base.py
@@ -116,6 +116,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+DOMAIN_NAME = "spadd.org"
 
 LOGIN_URL = "/admin/login"
 LOGOUT_URL = "logout"
@@ -127,7 +128,7 @@ EMAIL_USE_TLS = True
 EMAIL_PORT = 587
 EMAIL_HOST_USER = "apikey"  # this is exactly the value 'apikey'
 EMAIL_HOST_PASSWORD = os.getenv("EMAIL_API_KEY", None)
-EMAIL_FROM = "admin@spadd.org"
+EMAIL_FROM = f"admin@{DOMAIN_NAME}"
 EMAIL_SUBJECT_PREFIX = "SPaDD"
 
 # Internationalization

--- a/biospecdb/urls.py
+++ b/biospecdb/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 
 from decorator_include import decorator_include
 from django.contrib import admin
+from django.contrib.auth import views as auth_views
 from django.contrib.auth.decorators import user_passes_test
 from django.urls import include, path
 from django.conf import settings
@@ -27,20 +28,35 @@ from uploader import views
 from uploader.admin import data_admin
 from catalog.admin import catalog_admin
 
-admin.site.site_header = "Biosample Spectral Repository administration"
+
+admin.site.site_header = "Biosample Spectral Repository"
 
 urlpatterns = [
     path(r"healthz/", include("health_check.urls")),
     path("favicon.ico", views.favicon),
     path('', RedirectView.as_view(pattern_name="home", permanent=True)),
     path('uploader/', include('biospecdb.apps.uploader.urls')),
-    path('admin/', admin.site.urls),
     path('home/', views.home, name='home'),
     path('explorer/', decorator_include(user_passes_test(lambda x: x.is_superuser or getattr(x, "is_sqluser", False),
                                                          login_url="/admin/login/"),
                                         'explorer.urls')),
     path('data/', data_admin.urls),
     path('catalog/', catalog_admin.urls),
+
+    path("admin/password_reset/",
+         auth_views.PasswordResetView.as_view(from_email=settings.EMAIL_FROM,
+                                              extra_context={"site_header": admin.site.site_header}),
+         name="admin_password_reset"),
+    path("admin/password_reset/done/",
+         auth_views.PasswordResetDoneView.as_view(extra_context={"site_header": admin.site.site_header}),
+         name="password_reset_done"),
+    path("reset/<uidb64>/<token>/",
+         auth_views.PasswordResetConfirmView.as_view(extra_context={"site_header": admin.site.site_header}),
+         name="password_reset_confirm"),
+    path("reset/done/",
+         auth_views.PasswordResetCompleteView.as_view(extra_context={"site_header": admin.site.site_header}),
+         name="password_reset_complete"),
+    path('admin/', admin.site.urls)
 ]
 
 if settings.DEBUG:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       && python manage.py loaddata centers queries
       && python manage.py loaddata --database=bsr centers observables instruments qcannotators biosampletypes spectrameasurementtypes
       && python manage.py update_sql_views
-      && DJANGO_SUPERUSER_PASSWORD=$(cat /run/secrets/superuser_password) python manage.py createsuperuser --noinput --username=admin --email=admin@spadd.org --center=16721944-ff91-4adf-8fb3-323b99aba801
+      && DJANGO_SUPERUSER_PASSWORD=$(cat /run/secrets/superuser_password) python manage.py createsuperuser --noinput --username=admin --email=admin@spadda.org --center=16721944-ff91-4adf-8fb3-323b99aba801
       && touch /app/db/setup_complete.txt || echo done!"
 
   web:
@@ -83,7 +83,6 @@ services:
     ports:
       - "80:80"
       - "443:443"
-      - "587:587"
     volumes:
       - static_files:/static
       - spectaldata-files:/spectral_data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       && python manage.py loaddata centers queries
       && python manage.py loaddata --database=bsr centers observables instruments qcannotators biosampletypes spectrameasurementtypes
       && python manage.py update_sql_views
-      && DJANGO_SUPERUSER_PASSWORD=$(cat /run/secrets/superuser_password) python manage.py createsuperuser --noinput --username=admin --email=admin@jhu.edu --center=d61f1c2a-9c0a-4309-a031-ab5b8d2106b0
+      && DJANGO_SUPERUSER_PASSWORD=$(cat /run/secrets/superuser_password) python manage.py createsuperuser --noinput --username=admin --email=admin@spadd.org --center=16721944-ff91-4adf-8fb3-323b99aba801
       && touch /app/db/setup_complete.txt || echo done!"
 
   web:
@@ -57,11 +57,12 @@ services:
       DJANGO_SETTINGS_MODULE: biospecdb.settings.prd
     secrets:
       - django_secret_key
+      - email_api_key
     command: >
       bash -c "mkdir -p log
       && mkdir -p run
       && SECRET_KEY=$(cat /run/secrets/django_secret_key) python manage.py collectstatic --clear --noinput
-      && SECRET_KEY=$(cat /run/secrets/django_secret_key) gunicorn -c config/gunicorn/prd.py"
+      && SECRET_KEY=$(cat /run/secrets/django_secret_key) EMAIL_API_KEY=$(cat /run/secrets/email_api_key) gunicorn -c config/gunicorn/prd.py"
     healthcheck:
       test: ["CMD-SHELL", "curl --head --fail --header 'X-Forwarded-Proto: https' http://localhost:8000/healthz/ || exit 1"]
       interval: 60s
@@ -82,6 +83,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
+      - "587:587"
     volumes:
       - static_files:/static
       - spectaldata-files:/spectral_data
@@ -96,6 +98,9 @@ secrets:
     environment: DJANGO_SUPERUSER_PASSWORD
   django_secret_key:
     environment: SECRET_KEY
+  email_api_key:
+    environment: EMAIL_API_KEY
+
 
 volumes:
   db-data:


### PR DESCRIPTION
Resolves [Notion ticket](https://www.notion.so/Password-reset-functionality-b03673ce553c42058235cf9e48141e7d?pvs=4)

I've setup a temp account on sendgrid.com to test and verify this implementation, and it works.

We'll need to setup the official account, which requires the final domain name and access to the DNS registrar to complete the setup on sendgrid.