### PR TITLE
Add version view

### DIFF
--- a/biospecdb/apps/uploader/views.py
+++ b/biospecdb/apps/uploader/views.py
@@ -6,6 +6,7 @@ from django.http import FileResponse, HttpRequest, HttpResponse
 from django.views.decorators.cache import cache_control
 from django.views.decorators.http import require_GET
 
+from biospecdb import __version__
 
 @require_GET
 @cache_control(max_age=60 * 60 * 24, immutable=True, public=True)  # one day
@@ -17,3 +18,7 @@ def favicon(request: HttpRequest) -> HttpResponse:
 @staff_member_required
 def home(request):
     return render(request, 'Home.html')
+
+
+def version(request):
+    return HttpResponse(f"<h1>Version: '{__version__}'</h1>")

--- a/biospecdb/urls.py
+++ b/biospecdb/urls.py
@@ -33,6 +33,7 @@ admin.site.site_header = "Biosample Spectral Repository"
 
 urlpatterns = [
     path(r"healthz/", include("health_check.urls")),
+    path("version/", views.version, name="version"),
     path("favicon.ico", views.favicon),
     path('', RedirectView.as_view(pattern_name="home", permanent=True)),
     path('uploader/', include('biospecdb.apps.uploader.urls')),

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,10 @@
+from biospecdb import __version__
+
+from django.test import Client
+
+
+def test_version():
+    response = Client().get("/version/")
+    assert response.status_code == 200
+    assert __version__
+    assert __version__ in response.content.decode()


### PR DESCRIPTION
Resolves [Notion ticket](https://www.notion.so/Add-path-to-return-app-version-81344ab64d28469e82d6a03bcd8f5f81?pvs=4)

``_version__`` is populated from ``_version`` which is created by the build - this may need some alteration with respect to #255 (which will take place in that PR).