### PR TITLE
Use Django storage API for all file access

### DIFF
--- a/biospecdb/apps/uploader/exporters.py
+++ b/biospecdb/apps/uploader/exporters.py
@@ -3,7 +3,6 @@ import tempfile
 import zipfile
 
 from django.conf import settings
-from django.core.files.storage import storages
 from django.utils.module_loading import import_string
 import explorer.exporters
 import pandas as pd
@@ -74,6 +73,7 @@ class ZipSpectralDataMixin:
 
         data_files = []
         if include_data_files:
+            storage = SpectralData.data.field.storage
             # Collect SpectralData files and zip along with query data from self._get_output().
             if settings.EXPLORER_DATA_EXPORTERS_ALLOW_DATA_FILE_ALIAS:
                 # Spectral data files are modeled by the Spectraldata.data field, however, the sql query could have
@@ -109,11 +109,11 @@ class ZipSpectralDataMixin:
                 # Add all data files to zipfile.
                 for filename in data_files:
                     try:
-                        archive.write(storages["default"].path(filename), arcname=filename)
+                        archive.write(storage.path(filename), arcname=filename)
                     except NotImplementedError:
-                        # storages["default"].path() will raise NotImplementedError for remote storages like S3. In this
+                        # storage.path() will raise NotImplementedError for remote storages like S3. In this
                         # scenario, open and read all the file contents to zip.
-                        with storages["default"].open(filename) as fp:
+                        with storage.open(filename) as fp:
                             data = fp.read()
                         archive.writestr(filename, data)
             temp.seek(0)

--- a/biospecdb/apps/uploader/management/commands/prune_files.py
+++ b/biospecdb/apps/uploader/management/commands/prune_files.py
@@ -24,23 +24,21 @@ class Command(BaseCommand):
                 self.stdout.write(self.style.WARNING("No orphaned files detected."))
                 return
 
-            n_orphaned_files = 0
-            for x in all_orphaned_files:
-                n_orphaned_files += len(x[1])
+            n_orphaned_files = sum(len(x) for _, x in all_orphaned_files)
 
             # Delete orphaned files.
             n_deleted = 0
             for storage, files in all_orphaned_files:
                 for file in files:
-                    n_deleted += 1
-
-                    msg = f"{n_deleted}/{n_orphaned_files} files: '{file}'..."
+                    msg = f"{n_deleted + 1}/{n_orphaned_files} files: '{file}'..."
                     if options["dry_run"]:
                         self.stdout.write("(dry-run) " + msg)
+                        n_deleted += 1
                     else:
                         self.stdout.write(f"Deleting {msg}")
                         try:
                             storage.delete(file)
+                            n_deleted += 1
                         except FileNotFoundError:
                             continue
 

--- a/biospecdb/apps/uploader/management/commands/prune_files.py
+++ b/biospecdb/apps/uploader/management/commands/prune_files.py
@@ -1,9 +1,5 @@
-import os
-from pathlib import Path
-
+from django.apps import apps
 from django.core.management.base import BaseCommand, CommandError
-
-from uploader.models import SpectralData, UploadedFile
 
 
 class Command(BaseCommand):
@@ -16,38 +12,42 @@ class Command(BaseCommand):
                             help="Output files to be deleted but don't actually delete anything.")
 
     def handle(self, *args, **options):
+        all_orphaned_files = []
         try:
-            # Collect orphaned bulk data files.
-            fs_files = set(Path(UploadedFile.UPLOAD_DIR).glob("*"))
-            meta_data_files = set(x.meta_data_file.name for x in UploadedFile.objects.all())
-            spectral_data_files = set(x.spectral_data_file.name for x in UploadedFile.objects.all())
-            orphaned_files = fs_files - (meta_data_files | spectral_data_files)
+            for model in apps.get_models():
+                if hasattr(model, "get_orphan_files"):
+                    storage, orphaned_files = model.get_orphan_files()
+                    if orphaned_files:
+                        all_orphaned_files.append((storage, orphaned_files))
 
-            # Collect orphaned spectral data files.
-            fs_files = set(Path(SpectralData.UPLOAD_DIR).glob("*"))
-            data_files = set(x.data.name for x in SpectralData.objects.all())
-            orphaned_files |= fs_files - data_files
-
-            if not orphaned_files:
+            if not all_orphaned_files:
                 self.stdout.write(self.style.WARNING("No orphaned files detected."))
                 return
 
+            n_orphaned_files = 0
+            for x in all_orphaned_files:
+                n_orphaned_files += len(x[1])
+
             # Delete orphaned files.
-            for i, file in enumerate(orphaned_files):
-                msg = f"{i + 1}/{len(orphaned_files)} files: '{file}'..."
-                if options["dry_run"]:
-                    self.stdout.write("(dry-run) " + msg)
-                else:
-                    self.stdout.write(f"Deleting {msg}")
-                    try:
-                        os.remove(file)
-                    except FileNotFoundError:
-                        continue
+            n_deleted = 0
+            for storage, files in all_orphaned_files:
+                for file in files:
+                    n_deleted += 1
+
+                    msg = f"{n_deleted}/{n_orphaned_files} files: '{file}'..."
+                    if options["dry_run"]:
+                        self.stdout.write("(dry-run) " + msg)
+                    else:
+                        self.stdout.write(f"Deleting {msg}")
+                        try:
+                            storage.delete(file)
+                        except FileNotFoundError:
+                            continue
 
             if options["dry_run"]:
                 self.stdout.write(self.style.SUCCESS("(dry-run) [Done] 0 files deleted"))
             else:
-                self.stdout.write(self.style.SUCCESS(f"[Done] {len(orphaned_files)} files deleted"))
+                self.stdout.write(self.style.SUCCESS(f"[Done] {n_deleted} files deleted"))
 
         except Exception as error:
             raise CommandError(f"An error occurred whilst trying to delete orphaned data files: - '{error}'")

--- a/biospecdb/apps/uploader/tests/conftest.py
+++ b/biospecdb/apps/uploader/tests/conftest.py
@@ -57,6 +57,12 @@ def rm_all_media_dirs():
     rm_dir(Path(Dataset.UPLOAD_DIR))
 
 
+@pytest.fixture(scope="function", autouse=True)
+def clean_up():
+    yield
+    rm_all_media_dirs()
+
+
 class SimpleQueryFactory(DjangoModelFactory):
 
     class Meta:
@@ -183,7 +189,6 @@ def mock_data_from_files(request,
 
     with django_db_blocker.unblock():
         bulk_upload()
-
 
     yield
 

--- a/biospecdb/apps/uploader/tests/test_io.py
+++ b/biospecdb/apps/uploader/tests/test_io.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from django.core.files.base import ContentFile
+from django.core.files.storage import storages
 
 import uploader.io
 from uploader.tests.conftest import DATA_PATH
@@ -63,18 +64,18 @@ class TestSpectralDataToJson:
         assert isinstance(json_str, str)
         assert json.loads(json_str) == json_data
 
-    def test_data_as_filename(self, json_data, tmp_path):
-        filename = (Path(tmp_path)/"myjson").with_suffix(uploader.io.FileFormats.JSONL)
+    def test_data_as_filename(self, json_data):
+        filename = Path("myjson").with_suffix(uploader.io.FileFormats.JSONL)
         # Write data.
-        uploader.io.spectral_data_to_json(filename, json_data)
+        filename = uploader.io.spectral_data_to_json(filename, json_data)
         # Read data.
         data = uploader.io.spectral_data_from_json(filename)
         assert uploader.io.SpectralData(**json_data) == data
 
-    def test_data_as_fp(self, json_data, tmp_path):
-        filename = (Path(tmp_path)/"myjson").with_suffix(uploader.io.FileFormats.JSONL)
+    def test_data_as_fp(self, json_data):
+        filename = Path("myjson").with_suffix(uploader.io.FileFormats.JSONL)
         # Write data.
-        with filename.open(mode='w') as fp:
+        with storages["default"].open(filename, mode='w') as fp:
             uploader.io.spectral_data_to_json(fp, json_data)
         # Read data.
         data = uploader.io.spectral_data_from_json(filename)

--- a/biospecdb/apps/uploader/tests/test_models.py
+++ b/biospecdb/apps/uploader/tests/test_models.py
@@ -391,9 +391,9 @@ class TestSpectralData:
     def test_deletion(self, mock_data_from_files):
         spectral_data = SpectralData.objects.all()
         for item in spectral_data:
-            assert os.path.exists(item.data.name)
+            assert SpectralData.data.field.storage.exists(item.data.name)
             item.delete()
-            assert not os.path.exists(item.data.name)
+            assert not SpectralData.data.field.storage.exists(item.data.name)
         assert not SpectralData.objects.count()
 
 


### PR DESCRIPTION
Resolves [Notion ticket](https://www.notion.so/Use-Django-storage-API-357f4fa8bbf1469b818561f88b78e3aa?pvs=4)

Django's storage API must be used, rather than Python's functionality, i.e., ``open``, ``os.remove``, so that non-fs storages, i.e., AWS S3, can be utilized.

Reimplements ``prun_files`` from #220

Required by #255

I've manually tested that this works with S3.
 - [x] Media files written to S3.
 - [x] Media files downloadable from S3, via BSR web app.
 - [x] Data archived/zipped correctly for:
   - [x] Cataloged datasets.
   - [x] From SQL explorer.